### PR TITLE
feat : MovieContent 이미지/영상 URL 업로드 및 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+    // AWS S3
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/net/pointofviews/common/config/S3Config.java
+++ b/src/main/java/net/pointofviews/common/config/S3Config.java
@@ -1,0 +1,30 @@
+package net.pointofviews.common.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/net/pointofviews/movie/controller/MovieController.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieController.java
@@ -1,16 +1,25 @@
 package net.pointofviews.movie.controller;
 
+import lombok.RequiredArgsConstructor;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.movie.dto.SearchMovieCriteria;
 import net.pointofviews.movie.dto.request.CreateMovieRequest;
 import net.pointofviews.movie.dto.request.CreateMovieContentRequest;
 import net.pointofviews.movie.dto.response.*;
+import net.pointofviews.movie.service.MovieContentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/movies")
+@RequiredArgsConstructor
 public class MovieController implements MovieSpecification {
+
+    private final MovieContentService movieContentService;
+
 
     @Override
     @PostMapping
@@ -44,8 +53,20 @@ public class MovieController implements MovieSpecification {
 
     @Override
     @PostMapping("/{movieId}/images")
-    public ResponseEntity<?> createImage(Long movieId, CreateMovieContentRequest createMovieContentRequest) {
-        return null;
+    public ResponseEntity<BaseResponse<List<String>>> createImage(
+            @PathVariable Long movieId,
+            @RequestParam("files") List<MultipartFile> files) {
+
+        try {
+            // 서비스에 요청 전달
+            List<String> imageUrls = movieContentService.saveMovieContentImages(movieId, files);
+
+            // 성공 응답
+            return BaseResponse.ok("이미지가 성공적으로 업로드되었습니다.", imageUrls);
+        } catch (Exception e) {
+            // 실패 응답
+            return BaseResponse.internalServerError("이미지 업로드 중 오류가 발생했습니다.", null);
+        }
     }
 
     @Override
@@ -55,9 +76,20 @@ public class MovieController implements MovieSpecification {
     }
 
     @Override
-    @DeleteMapping("/{movieId}/images/{id}")
-    public ResponseEntity<?> deleteImage(Long movieId, Long id) {
-        return null;
+    @DeleteMapping("/{movieId}/images")
+    public ResponseEntity<BaseResponse<Void>> deleteImages(
+            @PathVariable Long movieId,
+            @RequestBody List<Long> ids) {
+        try {
+            // 서비스 계층 호출
+            movieContentService.deleteMovieContentImages(ids);
+
+            // 성공 응답 반환
+            return BaseResponse.ok("선택한 이미지가 삭제되었습니다.");
+        } catch (Exception e) {
+            // 실패 응답 반환
+            return BaseResponse.internalServerError("이미지 삭제 중 오류가 발생했습니다.", null);
+        }
     }
 
     @Override

--- a/src/main/java/net/pointofviews/movie/controller/MovieController.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.movie.dto.SearchMovieCriteria;
 import net.pointofviews.movie.dto.request.CreateMovieRequest;
-import net.pointofviews.movie.dto.request.CreateMovieContentRequest;
 import net.pointofviews.movie.dto.response.*;
 import net.pointofviews.movie.service.MovieContentService;
 import org.springframework.http.ResponseEntity;
@@ -71,8 +70,17 @@ public class MovieController implements MovieSpecification {
 
     @Override
     @PostMapping("/{movieId}/videos")
-    public ResponseEntity<?> createVideo(Long movieId, CreateMovieContentRequest createMovieContentRequest) {
-        return null;
+    public ResponseEntity<BaseResponse<List<String>>> createVideo(@PathVariable Long movieId, @RequestParam("ids") List<String> ids) {
+        try {
+            // 서비스에 요청 전달
+            List<String> videoUrls = movieContentService.saveMovieContentVideos(movieId, ids);
+
+            // 성공 응답
+            return BaseResponse.ok("영상 URL 이 성공적으로 업로드 되었습니다.", videoUrls);
+        } catch (Exception e) {
+            // 실패 응답
+            return BaseResponse.internalServerError("영상 URL 업로드 중 오류가 발생했습니다.", null);
+        }
     }
 
     @Override
@@ -93,9 +101,20 @@ public class MovieController implements MovieSpecification {
     }
 
     @Override
-    @DeleteMapping("/{movieId}/videos/{id}")
-    public ResponseEntity<?> deleteVideo(Long movieId, Long id) {
-        return null;
+    @DeleteMapping("/{movieId}/videos")
+    public ResponseEntity<BaseResponse<Void>> deleteVideo(
+            @PathVariable Long movieId,
+            @RequestBody List<Long> ids) {
+        try {
+            // 서비스 계층 호출
+            movieContentService.deleteMovieContentVideos(ids);
+
+            // 성공 응답 반환
+            return BaseResponse.ok("선택한 영상이 삭제되었습니다.");
+        } catch (Exception e) {
+            // 실패 응답 반환
+            return BaseResponse.internalServerError("영상 삭제 중 오류가 발생했습니다.", null);
+        }
     }
 
     @Override

--- a/src/main/java/net/pointofviews/movie/controller/MovieController.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieController.java
@@ -52,33 +52,53 @@ public class MovieController implements MovieSpecification {
 
     @Override
     @PostMapping("/{movieId}/images")
-    public ResponseEntity<BaseResponse<List<String>>> createImage(
+    public ResponseEntity<BaseResponse<List<String>>> createImages(
             @PathVariable Long movieId,
             @RequestParam("files") List<MultipartFile> files) {
 
         try {
-            // 서비스에 요청 전달
+            // 1. 파일명 유효성 검사
+            for (MultipartFile file : files) {
+                String originalFilename = file.getOriginalFilename();
+                if (!originalFilename.matches("^[a-zA-Z0-9._\\-]+$")) {
+                    // 유효하지 않은 파일명일 경우 오류 응답 반환
+                    return BaseResponse.badRequest(
+                            "파일 이름은 영어, 숫자, 하이픈, 언더스코어, 또는 점만 포함해야 합니다: " + originalFilename,
+                            null
+                    );
+                }
+            }
+
+            // 2. 서비스에 요청 전달
             List<String> imageUrls = movieContentService.saveMovieContentImages(movieId, files);
 
-            // 성공 응답
+            // 3. 성공 응답
             return BaseResponse.ok("이미지가 성공적으로 업로드되었습니다.", imageUrls);
+
         } catch (Exception e) {
-            // 실패 응답
+            // 4. 실패 응답
             return BaseResponse.internalServerError("이미지 업로드 중 오류가 발생했습니다.", null);
         }
     }
 
     @Override
     @PostMapping("/{movieId}/videos")
-    public ResponseEntity<BaseResponse<List<String>>> createVideo(@PathVariable Long movieId, @RequestParam("ids") List<String> ids) {
+    public ResponseEntity<BaseResponse<List<String>>> createVideos(@PathVariable Long movieId, @RequestParam("ids") List<String> urls) {
         try {
-            // 서비스에 요청 전달
-            List<String> videoUrls = movieContentService.saveMovieContentVideos(movieId, ids);
+            // 1. URL 유효성 검사
+            for (String url : urls) {
+                if (!isValidYouTubeUrl(url)) {
+                    return BaseResponse.badRequest("유효하지 않은 유튜브 URL입니다: " + url, null);
+                }
+            }
 
-            // 성공 응답
+            // 2. 서비스에 요청 전달
+            List<String> videoUrls = movieContentService.saveMovieContentVideos(movieId, urls);
+
+            // 3. 성공 응답
             return BaseResponse.ok("영상 URL 이 성공적으로 업로드 되었습니다.", videoUrls);
         } catch (Exception e) {
-            // 실패 응답
+            // 4. 실패 응답
             return BaseResponse.internalServerError("영상 URL 업로드 중 오류가 발생했습니다.", null);
         }
     }
@@ -89,30 +109,46 @@ public class MovieController implements MovieSpecification {
             @PathVariable Long movieId,
             @RequestBody List<Long> ids) {
         try {
-            // 서비스 계층 호출
+            // 1. ID 유효성 검사
+            if (ids == null || ids.isEmpty()) {
+                return BaseResponse.badRequest("삭제할 이미지 ID가 제공되지 않았습니다.", null);
+            }
+
+            // 2. 서비스 계층 호출
             movieContentService.deleteMovieContentImages(ids);
 
-            // 성공 응답 반환
+            // 3. 성공 응답 반환
             return BaseResponse.ok("선택한 이미지가 삭제되었습니다.");
+        } catch (IllegalArgumentException e) {
+            // 타입 검증 실패 응답 반환
+            return BaseResponse.badRequest(e.getMessage(), null);
         } catch (Exception e) {
-            // 실패 응답 반환
+            // 기타 실패 응답 반환
             return BaseResponse.internalServerError("이미지 삭제 중 오류가 발생했습니다.", null);
         }
     }
 
     @Override
     @DeleteMapping("/{movieId}/videos")
-    public ResponseEntity<BaseResponse<Void>> deleteVideo(
+    public ResponseEntity<BaseResponse<Void>> deleteVideos(
             @PathVariable Long movieId,
             @RequestBody List<Long> ids) {
         try {
-            // 서비스 계층 호출
+            // 1. ID 유효성 검사
+            if (ids == null || ids.isEmpty()) {
+                return BaseResponse.badRequest("삭제할 영상 ID가 제공되지 않았습니다.", null);
+            }
+
+            // 2. 서비스 계층 호출
             movieContentService.deleteMovieContentVideos(ids);
 
-            // 성공 응답 반환
+            // 3. 성공 응답 반환
             return BaseResponse.ok("선택한 영상이 삭제되었습니다.");
+        } catch (IllegalArgumentException e) {
+            // 타입 검증 실패 응답 반환
+            return BaseResponse.badRequest(e.getMessage(), null);
         } catch (Exception e) {
-            // 실패 응답 반환
+            // 기타 실패 응답 반환
             return BaseResponse.internalServerError("영상 삭제 중 오류가 발생했습니다.", null);
         }
     }
@@ -123,4 +159,10 @@ public class MovieController implements MovieSpecification {
         return null;
     }
 
+
+    // 유튜브 도메인 유효성 검사
+    private boolean isValidYouTubeUrl(String url) {
+        String youtubeRegex = "^(https?://)?(www\\.)?(youtube\\.com|youtu\\.be)/.+$";
+        return url.matches(youtubeRegex);
+    }
 }

--- a/src/main/java/net/pointofviews/movie/controller/MovieController.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieController.java
@@ -83,7 +83,7 @@ public class MovieController implements MovieSpecification {
 
     @Override
     @PostMapping("/{movieId}/videos")
-    public ResponseEntity<BaseResponse<List<String>>> createVideos(@PathVariable Long movieId, @RequestParam("ids") List<String> urls) {
+    public ResponseEntity<BaseResponse<List<String>>> createVideos(@PathVariable Long movieId, @RequestParam("urls") List<String> urls) {
         try {
             // 1. URL 유효성 검사
             for (String url : urls) {

--- a/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
@@ -187,8 +187,7 @@ public interface MovieSpecification {
             )
     })
     ResponseEntity<?> createImage(
-            @PathVariable Long movieId,
-            @RequestParam("files") List<MultipartFile> files
+            @PathVariable Long movieId, @RequestParam("files") List<MultipartFile> files
     );
 
     // POST - 영상 URL 등록
@@ -208,8 +207,7 @@ public interface MovieSpecification {
             )
     })
     ResponseEntity<?> createVideo(
-            @PathVariable Long movieId,
-            @RequestBody CreateMovieContentRequest createMovieContentRequest
+            @PathVariable Long movieId, @RequestParam("urls") List<String> urls
     );
 
     // DELETE - 이미지 URL 삭제
@@ -275,7 +273,7 @@ public interface MovieSpecification {
     })
     ResponseEntity<?> deleteVideo(
             @PathVariable Long movieId,
-            @PathVariable Long id
+            @RequestBody List<Long> ids
     );
 
 

--- a/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
@@ -16,6 +16,9 @@ import net.pointofviews.movie.dto.response.SearchMovieListResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "Movie", description = "영화 관련 API")
 public interface MovieSpecification {
@@ -185,7 +188,7 @@ public interface MovieSpecification {
     })
     ResponseEntity<?> createImage(
             @PathVariable Long movieId,
-            @RequestBody CreateMovieContentRequest createMovieContentRequest
+            @RequestParam("files") List<MultipartFile> files
     );
 
     // POST - 영상 URL 등록
@@ -237,9 +240,9 @@ public interface MovieSpecification {
                     )
             )
     })
-    ResponseEntity<?> deleteImage(
+    ResponseEntity<?> deleteImages(
             @PathVariable Long movieId,
-            @PathVariable Long id
+            @RequestBody List<Long> ids
     );
 
     // DELETE - 영상 URL 삭제

--- a/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import net.pointofviews.common.dto.BaseResponse;
-import net.pointofviews.movie.dto.request.CreateMovieContentRequest;
 import net.pointofviews.movie.dto.SearchMovieCriteria;
 import net.pointofviews.movie.dto.request.CreateMovieRequest;
 import net.pointofviews.movie.dto.response.ReadDetailMovieResponse;
@@ -186,7 +185,7 @@ public interface MovieSpecification {
                     )
             )
     })
-    ResponseEntity<?> createImage(
+    ResponseEntity<?> createImages(
             @PathVariable Long movieId, @RequestParam("files") List<MultipartFile> files
     );
 
@@ -206,7 +205,7 @@ public interface MovieSpecification {
                     )
             )
     })
-    ResponseEntity<?> createVideo(
+    ResponseEntity<?> createVideos(
             @PathVariable Long movieId, @RequestParam("urls") List<String> urls
     );
 
@@ -271,7 +270,7 @@ public interface MovieSpecification {
                     )
             )
     })
-    ResponseEntity<?> deleteVideo(
+    ResponseEntity<?> deleteVideos(
             @PathVariable Long movieId,
             @RequestBody List<Long> ids
     );

--- a/src/main/java/net/pointofviews/movie/repository/MovieContentRepository.java
+++ b/src/main/java/net/pointofviews/movie/repository/MovieContentRepository.java
@@ -1,0 +1,9 @@
+package net.pointofviews.movie.repository;
+
+import net.pointofviews.movie.domain.MovieContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MovieContentRepository extends JpaRepository<MovieContent, Long> {
+}

--- a/src/main/java/net/pointofviews/movie/repository/MovieRepository.java
+++ b/src/main/java/net/pointofviews/movie/repository/MovieRepository.java
@@ -1,0 +1,9 @@
+package net.pointofviews.movie.repository;
+
+import net.pointofviews.movie.domain.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MovieRepository extends JpaRepository<Movie, Long> {
+}

--- a/src/main/java/net/pointofviews/movie/service/MovieContentService.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieContentService.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface MovieContentService {
     List<String> saveMovieContentImages(Long movieId, List<MultipartFile> files);
     void deleteMovieContentImages(List<Long> ids);
+    List<String> saveMovieContentVideos(Long movieId, List<String> urls);
+    void deleteMovieContentVideos(List<Long> ids);
 }

--- a/src/main/java/net/pointofviews/movie/service/MovieContentService.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieContentService.java
@@ -1,0 +1,10 @@
+package net.pointofviews.movie.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface MovieContentService {
+    List<String> saveMovieContentImages(Long movieId, List<MultipartFile> files);
+    void deleteMovieContentImages(List<Long> ids);
+}

--- a/src/main/java/net/pointofviews/movie/service/MovieContentServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieContentServiceImpl.java
@@ -1,0 +1,71 @@
+package net.pointofviews.movie.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import net.pointofviews.movie.domain.Movie;
+import net.pointofviews.movie.domain.MovieContent;
+import net.pointofviews.movie.domain.MovieContentType;
+import net.pointofviews.movie.repository.MovieContentRepository;
+import net.pointofviews.movie.repository.MovieRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MovieContentServiceImpl implements MovieContentService{
+
+    private final MovieRepository movieRepository;
+    private final MovieContentRepository movieContentRepository;
+    private final S3Service s3Service;
+
+    @Override
+    @Transactional
+    public List<String> saveMovieContentImages(Long movieId, List<MultipartFile> files) {
+
+        // 1. 영화 엔티티 조회
+        Movie movie = movieRepository.findById(movieId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화 ID입니다: " + movieId));
+
+        // 2. 결과 URL 리스트
+        List<String> imageUrls = new ArrayList<>();
+
+        // 3. 각 파일 처리
+        for (MultipartFile file : files) {
+            // S3에 이미지 업로드
+            String filePath = "movies/" + movieId + "/" + file.getOriginalFilename();
+            String imageUrl = s3Service.saveImage(file, filePath);
+            imageUrls.add(imageUrl);
+
+            // MovieContent 엔티티 생성 및 저장
+            MovieContent movieContent = MovieContent.builder()
+                    .movie(movie)
+                    .content(imageUrl)
+                    .contentType(MovieContentType.IMAGE)
+                    .build();
+            movieContentRepository.save(movieContent);
+        }
+
+        return imageUrls;
+    }
+
+
+    @Override
+    @Transactional
+    public void deleteMovieContentImages(List<Long> ids) {
+        // 1. ID 리스트로 MovieContent 엔티티 조회
+        List<MovieContent> contents = movieContentRepository.findAllById(ids);
+
+        // 2. S3에서 각 URL의 파일 삭제
+        for (MovieContent content : contents) {
+            String imageUrl = content.getContent();
+            s3Service.deleteImage(imageUrl);
+        }
+
+        // 3. MovieContent 레코드 삭제
+        movieContentRepository.deleteAll(contents);
+    }
+
+}

--- a/src/main/java/net/pointofviews/movie/service/MovieContentServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieContentServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -34,12 +35,27 @@ public class MovieContentServiceImpl implements MovieContentService{
 
         // 3. 각 파일 처리
         for (MultipartFile file : files) {
-            // S3에 이미지 업로드
-            String filePath = "movies/" + movieId + "/" + file.getOriginalFilename();
+            // 1. 원본 파일명 추출
+            String originalFilename = file.getOriginalFilename();
+
+            // 2. 파일 확장자 추출
+            String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+
+            // 3. 파일명에서 확장자 제거 (기존 이름만 사용)
+            String baseName = originalFilename.substring(0, originalFilename.lastIndexOf("."));
+
+            // 4. UUID 앞 5글자를 기존 이름 뒤에 추가한 고유 파일명 생성
+            String uniquePrefix = UUID.randomUUID().toString().substring(0, 5);
+            String uniqueFileName = baseName + "_" + uniquePrefix + extension;
+
+            // 5. S3에 업로드할 경로 생성
+            String filePath = "movies/" + movieId + "/" + uniqueFileName;
+
+            // 6. S3에 이미지 업로드
             String imageUrl = s3Service.saveImage(file, filePath);
             imageUrls.add(imageUrl);
 
-            // MovieContent 엔티티 생성 및 저장
+            // 7. MovieContent 엔티티 생성 및 저장
             MovieContent movieContent = MovieContent.builder()
                     .movie(movie)
                     .content(imageUrl)
@@ -58,13 +74,30 @@ public class MovieContentServiceImpl implements MovieContentService{
         // 1. ID 리스트로 MovieContent 엔티티 조회
         List<MovieContent> contents = movieContentRepository.findAllById(ids);
 
-        // 2. S3에서 각 URL의 파일 삭제
-        for (MovieContent content : contents) {
-            String imageUrl = content.getContent();
-            s3Service.deleteImage(imageUrl);
+        // 2. 존재하지 않는 ID 찾기
+        List<Long> foundIds = contents.stream()
+                .map(MovieContent::getId)
+                .toList();
+        List<Long> notFoundIds = ids.stream()
+                .filter(id -> !foundIds.contains(id))
+                .toList();
+        if (!notFoundIds.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 이미지 ID가 포함되어 있습니다: " + notFoundIds);
         }
 
-        // 3. MovieContent 레코드 삭제
+        // 2. IMAGE 타입 검증
+        for (MovieContent content : contents) {
+            if (content.getContentType() != MovieContentType.IMAGE) {
+                throw new IllegalArgumentException("ID " + content.getId() + "은(는) IMAGE 타입이 아닙니다.");
+            }
+        }
+
+        // 3. S3에서 각 URL의 파일 삭제
+        for (MovieContent content : contents) {
+            s3Service.deleteImage(content.getContent());
+        }
+
+        // 4. MovieContent 레코드 삭제
         movieContentRepository.deleteAll(contents);
     }
 
@@ -89,8 +122,28 @@ public class MovieContentServiceImpl implements MovieContentService{
 
     @Override
     public void deleteMovieContentVideos(List<Long> ids) {
-        // ID 리스트로 MovieContent 엔티티 조회
+        // 1. ID 리스트로 MovieContent 엔티티 조회
         List<MovieContent> contents = movieContentRepository.findAllById(ids);
+
+        // 존재하지 않는 ID 찾기
+        List<Long> foundIds = contents.stream()
+                .map(MovieContent::getId)
+                .toList();
+        List<Long> notFoundIds = ids.stream()
+                .filter(id -> !foundIds.contains(id))
+                .toList();
+        if (!notFoundIds.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 이미지 ID가 포함되어 있습니다: " + notFoundIds);
+        }
+
+        // 2. YOUTUBE 타입 검증
+        for (MovieContent content : contents) {
+            if (content.getContentType() != MovieContentType.YOUTUBE) {
+                throw new IllegalArgumentException("ID " + content.getId() + "은(는) YOUTUBE 타입이 아닙니다.");
+            }
+        }
+
+        // 3. MovieContent 레코드 삭제
         movieContentRepository.deleteAll(contents);
     }
 }

--- a/src/main/java/net/pointofviews/movie/service/MovieContentServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieContentServiceImpl.java
@@ -68,4 +68,29 @@ public class MovieContentServiceImpl implements MovieContentService{
         movieContentRepository.deleteAll(contents);
     }
 
+    @Override
+    public List<String> saveMovieContentVideos(Long movieId, List<String> urls) {
+        // 1. 영화 엔티티 조회
+        Movie movie = movieRepository.findById(movieId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화 ID입니다: " + movieId));
+
+        // 2. URL 저장
+        for(String url : urls) {
+            // MovieContent 엔티티 생성 및 저장
+            MovieContent movieContent = MovieContent.builder()
+                    .movie(movie)
+                    .content(url)
+                    .contentType(MovieContentType.YOUTUBE)
+                    .build();
+            movieContentRepository.save(movieContent);
+        }
+        return urls;
+    }
+
+    @Override
+    public void deleteMovieContentVideos(List<Long> ids) {
+        // ID 리스트로 MovieContent 엔티티 조회
+        List<MovieContent> contents = movieContentRepository.findAllById(ids);
+        movieContentRepository.deleteAll(contents);
+    }
 }

--- a/src/main/java/net/pointofviews/movie/service/S3Service.java
+++ b/src/main/java/net/pointofviews/movie/service/S3Service.java
@@ -1,0 +1,10 @@
+package net.pointofviews.movie.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+
+    String saveImage(MultipartFile image, String filePath);
+    void deleteImage(String imageAddress);
+
+}

--- a/src/main/java/net/pointofviews/movie/service/S3ServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/S3ServiceImpl.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.ByteArrayInputStream;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class S3ServiceImpl implements S3Service{
 
@@ -49,9 +51,9 @@ public class S3ServiceImpl implements S3Service{
         try {
             // S3 객체 삭제 요청
             amazonS3.deleteObject(bucketName, objectKey);
-            System.out.println("삭제 완료: " + objectKey);
+            log.info("S3에서 이미지 삭제 성공: {}", objectKey); // 삭제 성공 로그
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("S3에서 이미지 삭제 중 오류 발생: {}", e.getMessage(), e); // 에러 로그
             throw new RuntimeException("S3에서 이미지 삭제 중 오류 발생: " + e.getMessage());
         }
     }

--- a/src/main/java/net/pointofviews/movie/service/S3ServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/S3ServiceImpl.java
@@ -1,0 +1,58 @@
+package net.pointofviews.movie.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service{
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    @Override
+    public String saveImage(MultipartFile image, String filePath) {
+        String originalFilename = image.getOriginalFilename();
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+
+        try {
+            // InputStream 및 메타데이터 생성
+            byte[] bytes = image.getBytes();
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(bytes.length);
+            metadata.setContentType(image.getContentType());
+
+            // S3 업로드 요청 (ACL 설정 제거)
+            amazonS3.putObject(new PutObjectRequest(bucketName, filePath, new ByteArrayInputStream(bytes), metadata));
+
+            // 업로드된 파일의 URL 반환
+            return amazonS3.getUrl(bucketName, filePath).toString();
+        } catch (Exception e) {
+            throw new RuntimeException("S3 업로드 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteImage(String imageAddress) {
+        // S3 객체 키 추출
+        String objectKey = imageAddress.replace("https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/", "");
+
+        try {
+            // S3 객체 삭제 요청
+            amazonS3.deleteObject(bucketName, objectKey);
+            System.out.println("삭제 완료: " + objectKey);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("S3에서 이미지 삭제 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,18 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/test
+    url: jdbc:mysql://localhost:3306/pov
     username: root
-    password: root
+    password: root1234
+
+cloud:
+  aws:
+    credentials:
+      accessKey:
+      secretKey:
+    s3:
+      bucketName: bucket-uplus-127
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
     locations: classpath:db/migration
     baseline-version: 1
 
+  servlet:
+    multipart:
+      max-file-size: 10MB      # 단일 파일 크기 제한
+      max-request-size: 50MB   # 전체 요청 크기 제한
+
 springdoc:
   swagger-ui:
     path: /api-docs
@@ -26,3 +31,4 @@ springdoc:
 
   show-actuator: true
   default-consumes-media-type: application/json
+


### PR DESCRIPTION
## PR 설명
- S3 Config 설정
- AWS S3 의존성 추가
- application.yml 에 bucket 설정
- S3를 이용한 MovieContent 파일 이미지 업로드 / 삭제
- MovieContent 유튜브 URL 업로드 / 삭제

## 📸 스크린샷
<img width="1280" alt="스크린샷 2024-11-26 21 45 16" src="https://github.com/user-attachments/assets/cb37a085-db6f-491b-b95c-d48389ff2d1f">
<img width="945" alt="스크린샷 2024-11-26 21 45 38" src="https://github.com/user-attachments/assets/455fab78-90e0-415b-b62a-9f7db5a1f6bc">


## 고민과 해결과정
- 기존 API 명세서에 따르면 URL을 하나씩 저장하게끔 했으나, 편의성을 높이기 위해 여러개의 URL을 한 번에 삽입 삭제가 가능하게 변경함.