### PR TITLE
feat: 리뷰 등록, 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/net/pointofviews/auth/config/GlobalSecurityConfig.java
+++ b/src/main/java/net/pointofviews/auth/config/GlobalSecurityConfig.java
@@ -38,6 +38,7 @@ public class GlobalSecurityConfig {
                 new AntPathRequestMatcher("/error"),
                 new AntPathRequestMatcher("/actuator/**"),
                 new AntPathRequestMatcher("/auth/**"),
+                new AntPathRequestMatcher("/movies/**"),
                 PathRequest.toStaticResources().atCommonLocations()
         );
     }

--- a/src/main/java/net/pointofviews/auth/config/GlobalSecurityConfig.java
+++ b/src/main/java/net/pointofviews/auth/config/GlobalSecurityConfig.java
@@ -38,7 +38,6 @@ public class GlobalSecurityConfig {
                 new AntPathRequestMatcher("/error"),
                 new AntPathRequestMatcher("/actuator/**"),
                 new AntPathRequestMatcher("/auth/**"),
-                new AntPathRequestMatcher("/movies/**"),
                 PathRequest.toStaticResources().atCommonLocations()
         );
     }

--- a/src/main/java/net/pointofviews/common/domain/SoftDeleteEntity.java
+++ b/src/main/java/net/pointofviews/common/domain/SoftDeleteEntity.java
@@ -11,4 +11,8 @@ import java.time.LocalDateTime;
 public abstract class SoftDeleteEntity extends BaseEntity {
 
     private LocalDateTime deletedAt;
+
+    protected void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/net/pointofviews/review/controller/ReviewController.java
+++ b/src/main/java/net/pointofviews/review/controller/ReviewController.java
@@ -34,7 +34,8 @@ public class ReviewController implements ReviewSpecification {
 	@Override
 	@PostMapping("/{movieId}/reviews")
 	public ResponseEntity<BaseResponse<Void>> createReview(@PathVariable Long movieId, @Valid @RequestBody CreateReviewRequest request) {
-		return BaseResponse.created("", "리뷰가 성공적으로 등록되었습니다.");
+		reviewService.saveReview(movieId, request);
+		return BaseResponse.created("/movies/" + movieId + "/reviews", "리뷰가 성공적으로 등록되었습니다.");
 	}
 
 	@Override
@@ -52,12 +53,14 @@ public class ReviewController implements ReviewSpecification {
 		@PathVariable Long reviewId,
 		@RequestBody PutReviewRequest request
 	) {
+		reviewService.updateReview(movieId, reviewId, request);
 		return BaseResponse.ok("리뷰가 성공적으로 수정되었습니다.");
 	}
 
 	@Override
 	@DeleteMapping("/{movieId}/reviews/{reviewId}")
 	public ResponseEntity<BaseResponse<Void>> deleteReview(@PathVariable Long movieId, @PathVariable Long reviewId) {
+		reviewService.deleteReview(movieId, reviewId);
 		return BaseResponse.ok("리뷰가 성공적으로 삭제되었습니다.");
 	}
 

--- a/src/main/java/net/pointofviews/review/domain/Review.java
+++ b/src/main/java/net/pointofviews/review/domain/Review.java
@@ -52,10 +52,11 @@ public class Review extends SoftDeleteEntity {
     private LocalDateTime modifiedAt;
 
     @Builder
-    private Review(Member member, String title, String contents, String preference, boolean isSpoiler) {
+    private Review(Member member, Movie movie, String title, String contents, String preference, boolean isSpoiler) {
         Assert.notNull(title, "Title must not be null");
 
         this.member = member;
+        setMovie(movie);
         this.title = title;
         this.contents = contents;
         this.preference = preference;

--- a/src/main/java/net/pointofviews/review/domain/Review.java
+++ b/src/main/java/net/pointofviews/review/domain/Review.java
@@ -71,4 +71,16 @@ public class Review extends SoftDeleteEntity {
             movie.getReviews().add(this);
         }
     }
+
+    public void update(String title, String contents) {
+        Assert.notNull(title, "Title must not be null");
+        Assert.notNull(contents, "Contents must not be null");
+
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public void delete() {
+        setDeletedAt(LocalDateTime.now());
+    }
 }

--- a/src/main/java/net/pointofviews/review/exception/ReviewNotFoundException.java
+++ b/src/main/java/net/pointofviews/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,11 @@
+package net.pointofviews.review.exception;
+
+import org.springframework.http.HttpStatus;
+import net.pointofviews.common.exception.BusinessException;
+
+public class ReviewNotFoundException extends BusinessException {
+
+  public ReviewNotFoundException() {
+    super(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다.");
+  }
+}

--- a/src/main/java/net/pointofviews/review/repository/ReviewKeywordLinkRepository.java
+++ b/src/main/java/net/pointofviews/review/repository/ReviewKeywordLinkRepository.java
@@ -1,0 +1,7 @@
+package net.pointofviews.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import net.pointofviews.review.domain.ReviewKeywordLink;
+
+public interface ReviewKeywordLinkRepository extends JpaRepository<ReviewKeywordLink, Long> {
+}

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
@@ -49,9 +49,9 @@ public class ReviewServiceImpl implements ReviewService {
 				.contents(request.contents())
 				.preference(request.preference())
 				.isSpoiler(request.spoiler())
+				.movie(movie)
 				.build();
 
-		review.setMovie(movie);
 		reviewRepository.save(review);
 
 		// 키워드 저장

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
@@ -40,11 +40,8 @@ public class ReviewServiceImpl implements ReviewService {
 	@Transactional
 	public void saveReview(Long movieId, CreateReviewRequest request) {
 
-		if (movieRepository.findById(movieId).isEmpty()) {
-			throw new MovieNotFoundException();
-		}
-
-		Movie movie = movieRepository.findById(movieId).get();
+		 Movie movie = movieRepository.findById(movieId)
+            		.orElseThrow(MovieNotFoundException::new);
 
 		// 리뷰 생성 및 저장
 		Review review = Review.builder()

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,6 +1,5 @@
 -- 1. 독립적인 테이블 먼저 생성
 CREATE TABLE common_code_group (
-                                   disabled bit not null,
                                    common_code_group_description varchar(255) null,
                                    common_code_group_name varchar(255) null,
                                    is_active bit not null,
@@ -53,7 +52,6 @@ CREATE TABLE premiere (
 
 -- 2. 외래키를 가진 테이블들 생성
 CREATE TABLE common_code (
-                             disabled bit not null,
                              code varchar(255) not null primary key,
                              common_code_description varchar(255) null,
                              common_code_name varchar(255) null,

--- a/src/test/java/net/pointofviews/review/domain/ReviewTest.java
+++ b/src/test/java/net/pointofviews/review/domain/ReviewTest.java
@@ -3,13 +3,17 @@ package net.pointofviews.review.domain;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import net.pointofviews.movie.domain.Movie;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import net.pointofviews.member.domain.Member;
+
+import java.util.ArrayList;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewTest {
@@ -24,14 +28,18 @@ class ReviewTest {
             void Review_객체_생성() {
                 // given
                 Member member = mock(Member.class);
+                Movie movie = mock(Movie.class);
                 String title = "리뷰 제목";
                 String contents = "리뷰 내용";
                 boolean isSpoiler = true;
                 String preference = "긍정적";
 
+                BDDMockito.given(movie.getReviews()).willReturn(new ArrayList<>());
+
                 // when
                 Review review = Review.builder()
                         .member(member)
+                        .movie(movie)
                         .title(title)
                         .contents(contents)
                         .isSpoiler(isSpoiler)
@@ -42,6 +50,7 @@ class ReviewTest {
                 SoftAssertions.assertSoftly(softly -> {
                     softly.assertThat(review).isNotNull();
                     softly.assertThat(review.getMember()).isEqualTo(member);
+                    softly.assertThat(review.getMovie()).isEqualTo(movie);
                     softly.assertThat(review.getTitle()).isEqualTo(title);
                     softly.assertThat(review.getContents()).isEqualTo(contents);
                     softly.assertThat(review.isSpoiler()).isEqualTo(isSpoiler);
@@ -59,6 +68,7 @@ class ReviewTest {
             void 제목_없음_IllegalArgumentException_예외발생() {
                 // given
                 Member member = mock(Member.class);
+                Movie movie = mock(Movie.class);
                 String contents = "리뷰 내용";
                 boolean isSpoiler = false;
                 String preference = "긍정적";
@@ -66,6 +76,7 @@ class ReviewTest {
                 // when & then
                 assertThatThrownBy(() -> Review.builder()
                         .member(member)
+                        .movie(movie)
                         .contents(contents)
                         .isSpoiler(isSpoiler)
                         .preference(preference)

--- a/src/test/java/net/pointofviews/review/service/ReviewServiceTest.java
+++ b/src/test/java/net/pointofviews/review/service/ReviewServiceTest.java
@@ -7,6 +7,9 @@ import static org.mockito.BDDMockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import net.pointofviews.review.dto.request.CreateReviewRequest;
+import net.pointofviews.review.dto.request.PutReviewRequest;
+import net.pointofviews.review.exception.ReviewNotFoundException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +28,7 @@ import net.pointofviews.movie.repository.MovieRepository;
 import net.pointofviews.review.domain.Review;
 import net.pointofviews.review.dto.response.ReadReviewListResponse;
 import net.pointofviews.review.repository.ReviewLikeCountRepository;
+import net.pointofviews.review.repository.ReviewKeywordLinkRepository;
 import net.pointofviews.review.repository.ReviewLikeRepository;
 import net.pointofviews.review.repository.ReviewRepository;
 import net.pointofviews.review.service.impl.ReviewServiceImpl;
@@ -46,6 +50,203 @@ class ReviewServiceTest {
 
 	@Mock
 	private ReviewLikeCountRepository reviewLikeCountRepository;
+
+	@Mock
+	private ReviewKeywordLinkRepository reviewKeywordLinkRepository;
+
+	@Nested
+	class SaveReview {
+		@Nested
+		class Success {
+			@Test
+			void 리뷰_등록_성공() {
+				// given
+				Movie movie = mock(Movie.class);
+				given(movieRepository.findById(any())).willReturn(Optional.of(movie));
+
+				CreateReviewRequest request = new CreateReviewRequest(
+						"제목",
+						"내용",
+						"긍정적",
+						List.of("01", "02"),
+						false
+				);
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatCode(() -> reviewService.saveReview(1L, request))
+							.doesNotThrowAnyException();
+				});
+			}
+
+			@Test
+			void 키워드없이_리뷰_등록_성공() {
+				// given
+				Movie movie = mock(Movie.class);
+				given(movieRepository.findById(any())).willReturn(Optional.of(movie));
+
+				// null 케이스
+				CreateReviewRequest nullRequest = new CreateReviewRequest(
+						"제목",
+						"내용",
+						"긍정적",
+						null,
+						false
+				);
+
+				// 빈 리스트 케이스
+				CreateReviewRequest emptyRequest = new CreateReviewRequest(
+						"제목",
+						"내용",
+						"긍정적",
+						List.of(),
+						false
+				);
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatCode(() -> reviewService.saveReview(1L, nullRequest))
+							.doesNotThrowAnyException();
+					softly.assertThatCode(() -> reviewService.saveReview(1L, emptyRequest))
+							.doesNotThrowAnyException();
+				});
+			}
+		}
+
+		@Nested
+		class Failure {
+			@Test
+			void 존재하지_않는_영화_MovieNotFoundException_예외발생() {
+				// given
+				given(movieRepository.findById(any())).willReturn(Optional.empty());
+
+				CreateReviewRequest request = new CreateReviewRequest(
+						"제목",
+						"내용",
+						"긍정적",
+						List.of("01"),
+						false
+				);
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatThrownBy(() -> reviewService.saveReview(1L, request))
+							.isInstanceOf(MovieNotFoundException.class);
+				});
+			}
+		}
+	}
+
+	@Nested
+	class UpdateReview {
+		@Nested
+		class Success {
+			@Test
+			void 리뷰_수정_성공() {
+				// given
+				Movie movie = mock(Movie.class);
+				Review review = mock(Review.class);
+
+				given(movieRepository.findById(any())).willReturn(Optional.of(movie));
+				given(reviewRepository.findById(any())).willReturn(Optional.of(review));
+
+				PutReviewRequest request = new PutReviewRequest(
+						"수정된 제목",
+						"수정된 내용"
+				);
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatCode(() -> reviewService.updateReview(1L, 1L, request))
+							.doesNotThrowAnyException();
+				});
+			}
+		}
+
+		@Nested
+		class Failure {
+			@Test
+			void 존재하지_않는_영화_MovieNotFoundException_예외발생() {
+				// given
+				given(movieRepository.findById(any())).willReturn(Optional.empty());
+
+				PutReviewRequest request = new PutReviewRequest("제목", "내용");
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatThrownBy(() -> reviewService.updateReview(1L, 1L, request))
+							.isInstanceOf(MovieNotFoundException.class);
+				});
+			}
+
+			@Test
+			void 존재하지_않는_리뷰_ReviewNotFoundException_예외발생() {
+				// given
+				Movie movie = mock(Movie.class);
+				given(movieRepository.findById(any())).willReturn(Optional.of(movie));
+				given(reviewRepository.findById(any())).willReturn(Optional.empty());
+
+				PutReviewRequest request = new PutReviewRequest("제목", "내용");
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatThrownBy(() -> reviewService.updateReview(1L, 1L, request))
+							.isInstanceOf(ReviewNotFoundException.class);
+				});
+			}
+		}
+	}
+
+	@Nested
+	class DeleteReview {
+		@Nested
+		class Success {
+			@Test
+			void 리뷰_삭제_성공() {
+				// given
+				Movie movie = mock(Movie.class);
+				Review review = mock(Review.class);
+
+				given(movieRepository.findById(any())).willReturn(Optional.of(movie));
+				given(reviewRepository.findById(any())).willReturn(Optional.of(review));
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatCode(() -> reviewService.deleteReview(1L, 1L))
+							.doesNotThrowAnyException();
+				});
+			}
+		}
+
+		@Nested
+		class Failure {
+			@Test
+			void 존재하지_않는_영화_MovieNotFoundException_예외발생() {
+				// given
+				given(movieRepository.findById(any())).willReturn(Optional.empty());
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatThrownBy(() -> reviewService.deleteReview(1L, 1L))
+							.isInstanceOf(MovieNotFoundException.class);
+				});
+			}
+
+			@Test
+			void 존재하지_않는_리뷰_ReviewNotFoundException_예외발생() {
+				// given
+				Movie movie = mock(Movie.class);
+				given(movieRepository.findById(any())).willReturn(Optional.of(movie));
+				given(reviewRepository.findById(any())).willReturn(Optional.empty());
+
+				// when & then
+				assertSoftly(softly -> {
+					softly.assertThatThrownBy(() -> reviewService.deleteReview(1L, 1L))
+							.isInstanceOf(ReviewNotFoundException.class);
+				});
+			}
+		}
+	}
 
 	@Nested
 	class FindReviewByMovie {


### PR DESCRIPTION
## PR 설명
- 리뷰 등록, 수정, 삭제 기능 구현 및 테스트코드 작성
- softdelete 내 setter추가
- GlovalSecurityConfig 롤백 (review관련 경로 추가후 삭제)

## 📸 스크린샷
<img width="836" alt="스크린샷 2024-11-27 오후 4 04 45" src="https://github.com/user-attachments/assets/7da71cb0-4974-4af2-8b95-f61663b04a89">
<img width="843" alt="스크린샷 2024-11-27 오후 4 04 51" src="https://github.com/user-attachments/assets/8f79d45d-7738-4045-901a-23d1e60896aa">
<img width="841" alt="스크린샷 2024-11-27 오후 4 04 57" src="https://github.com/user-attachments/assets/542f35b2-e1f9-4710-9edf-6ebadd575bea">

![스크린샷 2024-11-27 오후 4 23 10](https://github.com/user-attachments/assets/6a22563d-af89-4cf9-8c70-36c7c48ac396)


## 고민과 해결과정
- 리뷰에 필요한 사용자 인증관련한 security 및 jwt 관련 내용 로그인 기능 후 추가 예정