### PR TITLE
feat: 리뷰 상세 조회 비즈니스 로직 단위 테스트 작성

### DIFF
--- a/src/main/java/net/pointofviews/review/repository/ReviewRepository.java
+++ b/src/main/java/net/pointofviews/review/repository/ReviewRepository.java
@@ -23,8 +23,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 				CASE WHEN EXISTS (SELECT 1 FROM ReviewLike rl WHERE rl.review.id = r.id AND rl.isLiked = true) THEN true ELSE false END
 		 )
 		 FROM Review r
-		 JOIN FETCH r.member m
-		 JOIN FETCH r.movie mv
+		 JOIN r.member m
+		 JOIN r.movie mv
 		 WHERE mv.id = :movieId
 	""")
 	Slice<ReadReviewResponse> findAllWithLikesByMovieId(@Param("movieId") Long movieId, Pageable pageable);

--- a/src/main/java/net/pointofviews/review/repository/ReviewRepository.java
+++ b/src/main/java/net/pointofviews/review/repository/ReviewRepository.java
@@ -1,5 +1,7 @@
 package net.pointofviews.review.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,4 +31,12 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	""")
 	Slice<ReadReviewResponse> findAllWithLikesByMovieId(@Param("movieId") Long movieId, Pageable pageable);
 
+	@Query("""
+		SELECT r
+		  FROM Review r
+		  JOIN FETCH r.member m
+		  JOIN FETCH r.movie mv
+		 WHERE r.id = :reviewId
+	""")
+	Optional<Review> findReviewDetailById(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
@@ -111,25 +111,9 @@ public class ReviewServiceImpl implements ReviewService {
 			throw movieNotFound(movieId);
 		}
 
-		Slice<Review> reviews = reviewRepository.findAllByMovieId(movieId, pageable);
+		Slice<ReadReviewResponse> reviews = reviewRepository.findAllWithLikesByMovieId(movieId, pageable);
 
-		Slice<ReadReviewResponse> response = reviews.map(review -> {
-			Long likeAmount = reviewLikeCountRepository.getReviewLikeCountByReviewId(review.getId());
-			boolean isLiked = reviewLikeRepository.getIsLikedByReviewId(review.getId());
-
-			return new ReadReviewResponse(
-				review.getMovie().getTitle(),
-				review.getTitle(),
-				review.getContents(),
-				review.getMember().getNickname(),
-				review.getThumbnail(),
-				review.getCreatedAt(),
-				likeAmount,
-				isLiked
-			);
-		});
-
-		return new ReadReviewListResponse(response);
+		return new ReadReviewListResponse(reviews);
 	}
 
 	@Override

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewServiceImpl.java
@@ -124,7 +124,7 @@ public class ReviewServiceImpl implements ReviewService {
 	@Override
 	public ReadReviewResponse findReviewDetail(Long reviewId) {
 
-		Review review = reviewRepository.findById(reviewId)
+		Review review = reviewRepository.findReviewDetailById(reviewId)
 			.orElseThrow(() -> reviewNotFound(reviewId));
 
 		Long likeAmount = reviewLikeCountRepository.getReviewLikeCountByReviewId(reviewId);

--- a/src/test/java/net/pointofviews/review/service/ReviewServiceTest.java
+++ b/src/test/java/net/pointofviews/review/service/ReviewServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpStatus;
 
+import net.pointofviews.member.domain.Member;
 import net.pointofviews.movie.domain.Movie;
 import net.pointofviews.movie.exception.MovieException;
 import net.pointofviews.movie.repository.MovieRepository;
@@ -345,5 +346,63 @@ class ReviewServiceTest {
 			}
 		}
 	}
-  
+
+	@Nested
+	class FindReviewDetail {
+
+		@Nested
+		class Success {
+
+			@Test
+			void 리뷰_상세_조회() {
+				// given -- 테스트의 상태 설정
+				Movie movie = mock(Movie.class);
+				Member member = mock(Member.class);
+				Review review = mock(Review.class);
+
+				given(review.getMovie()).willReturn(movie);
+				given(review.getMember()).willReturn(member);
+
+				given(reviewRepository.findReviewDetailById(any())).willReturn(Optional.of(review));
+				given(reviewLikeRepository.getIsLikedByReviewId(any())).willReturn(true);
+				given(reviewLikeCountRepository.getReviewLikeCountByReviewId(any())).willReturn(10L);
+
+				// when -- 테스트하고자 하는 행동
+				ReadReviewResponse result = reviewService.findReviewDetail(1L);
+
+				// then -- 예상되는 변화 및 결과
+				assertSoftly(softly -> {
+					softly.assertThat(result).isNotNull();
+					softly.assertThat(result.movieTitle()).isEqualTo(movie.getTitle());
+					softly.assertThat(result.title()).isEqualTo(review.getTitle());
+					softly.assertThat(result.contents()).isEqualTo(review.getContents());
+					softly.assertThat(result.reviewer()).isEqualTo(member.getNickname());
+					softly.assertThat(result.thumbnail()).isEqualTo(review.getThumbnail());
+					softly.assertThat(result.likeAmount()).isEqualTo(10L);
+					softly.assertThat(result.isLiked()).isTrue();
+				});
+			}
+		}
+
+		@Nested
+		class Failure {
+
+			@Test
+			void 존재하지_않는_리뷰_ReviewException_reviewNotFound_예외발생() {
+				// given -- 테스트의 상태 설정
+				given(reviewRepository.findReviewDetailById(any())).willReturn(Optional.empty());
+
+				// when -- 테스트하고자 하는 행동
+				ReviewException exception = assertThrows(ReviewException.class, () ->
+					reviewService.findReviewDetail(-1L)
+				);
+
+				// then -- 예상되는 변화 및 결과
+				assertSoftly(softly -> {
+					softly.assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+					softly.assertThat(exception.getMessage()).isEqualTo("리뷰(Id: -1)는 존재하지 않습니다.");
+				});
+			}
+		}
+	}
 }


### PR DESCRIPTION
## PR 설명
- 영화별 리뷰 조회 시 N+1 문제 발생이 예상되어, 이를 DTO 기반으로 필요한 값만 추출하는 조인으로 쿼리 개선
- 리뷰 상세 조회 시 불필요한 LAZY 쿼리를 줄이고자 findReviewDetailById 쿼리 작성
- 리뷰 상세 조회 비즈니스 로직 단위 테스트 작성

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/26d558e1-0a3c-47d9-b509-e4844fb0219a)


## 고민과 해결과정
