### PR TITLE
feat: 회원 선호 장르 변경 구현

### DIFF
--- a/src/main/java/net/pointofviews/common/domain/BaseEntity.java
+++ b/src/main/java/net/pointofviews/common/domain/BaseEntity.java
@@ -1,13 +1,17 @@
 package net.pointofviews.common.domain;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-
-import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/net/pointofviews/member/controller/MemberController.java
+++ b/src/main/java/net/pointofviews/member/controller/MemberController.java
@@ -1,7 +1,5 @@
 package net.pointofviews.member.controller;
 
-import java.util.UUID;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.pointofviews.common.dto.BaseResponse;
@@ -28,8 +26,12 @@ public class MemberController implements MemberSpecification {
 
     @Override
     @PutMapping("/profiles/genres")
-    public ResponseEntity<BaseResponse<PutMemberGenreListResponse>> putGenres(PutMemberGenreListRequest request) {
-        PutMemberGenreListResponse response = memberService.updateGenre(request);
+    public ResponseEntity<BaseResponse<PutMemberGenreListResponse>> putGenres(
+        @AuthenticationPrincipal(expression = "member") Member loginMember,
+        @Valid @RequestBody PutMemberGenreListRequest request
+    ) {
+        PutMemberGenreListResponse response = memberService.updateGenre(loginMember, request);
+
         return BaseResponse.ok("장르 설정이 완료되었습니다.", response);
     }
 

--- a/src/main/java/net/pointofviews/member/controller/MemberSpecification.java
+++ b/src/main/java/net/pointofviews/member/controller/MemberSpecification.java
@@ -48,7 +48,7 @@ public interface MemberSpecification {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "⭕ SUCCESS"
 		),
-		@ApiResponse(responseCode = "404", description = "❌ FAIL",
+		@ApiResponse(responseCode = "400", description = "❌ FAIL",
 			content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
 				examples = @ExampleObject(value = """
 					{

--- a/src/main/java/net/pointofviews/member/controller/MemberSpecification.java
+++ b/src/main/java/net/pointofviews/member/controller/MemberSpecification.java
@@ -52,12 +52,16 @@ public interface MemberSpecification {
 			content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
 				examples = @ExampleObject(value = """
 					{
-					  "message": "장르 설정에 실패했습니다."
-					}""")
+					  "message": "잘못된 장르(Name: 시사교양)를 요청했습니다."
+					}
+					""")
 			)
 		)
 	})
-	ResponseEntity<BaseResponse<PutMemberGenreListResponse>> putGenres(@RequestBody PutMemberGenreListRequest request);
+	ResponseEntity<BaseResponse<PutMemberGenreListResponse>> putGenres(
+		@AuthenticationPrincipal(expression = "member") Member loginMember,
+		@Valid @RequestBody PutMemberGenreListRequest request
+	);
 
 	// 회원 프로필 이미지 변경
 	@Tag(name = "Member", description = "회원 프로필 이미지 변경 관련 API")

--- a/src/main/java/net/pointofviews/member/domain/MemberFavorGenre.java
+++ b/src/main/java/net/pointofviews/member/domain/MemberFavorGenre.java
@@ -1,16 +1,24 @@
 package net.pointofviews.member.domain;
 
-import jakarta.persistence.*;
+import net.pointofviews.common.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import net.pointofviews.common.domain.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberFavorGenre extends BaseEntity {
+public class MemberFavorGenre {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/net/pointofviews/member/exception/MemberException.java
+++ b/src/main/java/net/pointofviews/member/exception/MemberException.java
@@ -6,6 +6,7 @@ import net.pointofviews.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
 public class MemberException extends BusinessException {
+
     public MemberException(HttpStatus status, String message) {
         super(status, message);
     }
@@ -24,5 +25,9 @@ public class MemberException extends BusinessException {
 
     public static MemberException nicknameDuplicate() {
         return new MemberException(HttpStatus.CONFLICT, "닉네임 중복으로 인해 변경이 실패했습니다.");
+    }
+
+    public static MemberException memberGenreBadRequest(String genreName) {
+        return new MemberException(HttpStatus.BAD_REQUEST, String.format("잘못된 장르(Name: %s)를 요청했습니다.", genreName));
     }
 }

--- a/src/main/java/net/pointofviews/member/repository/MemberFavorGenreRepository.java
+++ b/src/main/java/net/pointofviews/member/repository/MemberFavorGenreRepository.java
@@ -1,0 +1,26 @@
+package net.pointofviews.member.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import net.pointofviews.member.domain.MemberFavorGenre;
+
+public interface MemberFavorGenreRepository extends JpaRepository<MemberFavorGenre, Long> {
+
+	List<MemberFavorGenre> findAllByMemberId(UUID memberId);
+
+	void deleteAllByMemberId(UUID member_id);
+
+	@Query(value = """
+		SELECT cc.code.code
+		  FROM CommonCode cc
+		 WHERE cc.description = :codeName
+		   AND cc.groupCode.groupCode = '010'
+	""")
+	String findGenreCodeByGenreName(@Param("codeName") String codeName);
+
+}

--- a/src/main/java/net/pointofviews/member/repository/MemberFavorGenreRepository.java
+++ b/src/main/java/net/pointofviews/member/repository/MemberFavorGenreRepository.java
@@ -1,5 +1,6 @@
 package net.pointofviews.member.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,16 +12,21 @@ import net.pointofviews.member.domain.MemberFavorGenre;
 
 public interface MemberFavorGenreRepository extends JpaRepository<MemberFavorGenre, Long> {
 
-	List<MemberFavorGenre> findAllByMemberId(UUID memberId);
+	@Query(value = """
+		SELECT mfg.genreCode
+		  FROM MemberFavorGenre mfg
+		 WHERE mfg.member.id = :memberId
+	""")
+	List<String> findGenreCodeByMemberId(UUID memberId);
 
-	void deleteAllByMemberId(UUID member_id);
+	void deleteByMemberIdAndGenreCodeIn(UUID memberId, Collection<String> genreCodes);
 
 	@Query(value = """
 		SELECT cc.code.code
 		  FROM CommonCode cc
-		 WHERE cc.description = :codeName
-		   AND cc.groupCode.groupCode = '010'
+		 WHERE cc.description = :genreName
+		   AND cc.groupCode.groupCode = :groupCode
 	""")
-	String findGenreCodeByGenreName(@Param("codeName") String codeName);
+	String findGenreCodeByGenreName(@Param("genreName") String genreName, @Param("groupCode") String groupCode);
 
 }

--- a/src/main/java/net/pointofviews/member/service/MemberService.java
+++ b/src/main/java/net/pointofviews/member/service/MemberService.java
@@ -15,11 +15,11 @@ public interface MemberService {
 
     void deleteMember();
 
-    PutMemberGenreListResponse updateGenre(PutMemberGenreListRequest request);
+    PutMemberGenreListResponse updateGenre(Member loginMember, PutMemberGenreListRequest request);
 
     PutMemberImageResponse updateImage(PutMemberImageRequest request);
 
-    PutMemberNicknameResponse updateNickname(Member member, PutMemberNicknameRequest request);
+    PutMemberNicknameResponse updateNickname(Member loginMember, PutMemberNicknameRequest request);
 
     PutMemberNoticeResponse updateNotice(PutMemberNoticeRequest request);
 }

--- a/src/main/java/net/pointofviews/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/member/service/impl/MemberServiceImpl.java
@@ -2,6 +2,10 @@ package net.pointofviews.member.service.impl;
 
 import static net.pointofviews.member.exception.MemberException.*;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +13,7 @@ import net.pointofviews.auth.dto.request.CreateMemberRequest;
 import net.pointofviews.auth.dto.request.LoginMemberRequest;
 import net.pointofviews.auth.dto.response.CreateMemberResponse;
 import net.pointofviews.auth.dto.response.LoginMemberResponse;
+import net.pointofviews.member.domain.MemberFavorGenre;
 import net.pointofviews.member.dto.request.PutMemberGenreListRequest;
 import net.pointofviews.member.dto.request.PutMemberImageRequest;
 import net.pointofviews.member.dto.request.PutMemberNicknameRequest;
@@ -20,6 +25,7 @@ import net.pointofviews.member.dto.response.PutMemberNoticeResponse;
 import net.pointofviews.auth.utils.JwtProvider;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.exception.MemberException;
+import net.pointofviews.member.repository.MemberFavorGenreRepository;
 import net.pointofviews.member.repository.MemberRepository;
 import net.pointofviews.member.service.MemberService;
 
@@ -30,66 +36,103 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
-    private final MemberRepository memberRepository;
-    private final JwtProvider jwtProvider;
+	private final MemberRepository memberRepository;
+	private final MemberFavorGenreRepository memberFavorGenreRepository;
+	private final JwtProvider jwtProvider;
 
-    @Override
-    public CreateMemberResponse signup(CreateMemberRequest request) {
-        return null;
-    }
+	@Override
+	public CreateMemberResponse signup(CreateMemberRequest request) {
+		return null;
+	}
 
-    @Override
-    public LoginMemberResponse login(LoginMemberRequest request) {
-        // 이메일로 회원 조회
-        Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(MemberException::memberNotFound);
+	@Override
+	public LoginMemberResponse login(LoginMemberRequest request) {
+		// 이메일로 회원 조회
+		Member member = memberRepository.findByEmail(request.email())
+			.orElseThrow(MemberException::memberNotFound);
 
-        if (!member.getSocialType().name().equals(request.socialType())) {
-            throw invalidSocialType();
-        }
+		if (!member.getSocialType().name().equals(request.socialType())) {
+			throw invalidSocialType();
+		}
 
-        // 응답 생성
-        return new LoginMemberResponse(
-                member.getId(),
-                member.getEmail(),
-                member.getNickname(),
-                member.getRoleType().name()
-        );
-    }
+		// 응답 생성
+		return new LoginMemberResponse(
+			member.getId(),
+			member.getEmail(),
+			member.getNickname(),
+			member.getRoleType().name()
+		);
+	}
 
-    @Override
-    public void deleteMember() {
+	@Override
+	public void deleteMember() {
 
-    }
+	}
 
-    @Override
-    public PutMemberGenreListResponse updateGenre(PutMemberGenreListRequest request) {
-        return null;
-    }
+	@Override
+	@Transactional
+	public PutMemberGenreListResponse updateGenre(Member loginMember, PutMemberGenreListRequest request) {
 
-    @Override
-    public PutMemberImageResponse updateImage(PutMemberImageRequest request) {
-        return null;
-    }
+		Member member = memberRepository.findById(loginMember.getId())
+			.orElseThrow(() -> memberNotFound(loginMember.getId()));
 
-    @Override
-    @Transactional
-    public PutMemberNicknameResponse updateNickname(Member loginMember, PutMemberNicknameRequest request) {
+		deleteExistingGenres(member);
 
-        Member member = memberRepository.findById(loginMember.getId())
-            .orElseThrow(() -> memberNotFound(loginMember.getId()));
+		List<String> newFavorGenres = saveNewGenres(request, member);
 
-        if (memberRepository.existsByNickname(request.nickname())) {
-            throw nicknameDuplicate();
-        }
+		return new PutMemberGenreListResponse(newFavorGenres);
+	}
 
-        member.updateNickname(request.nickname());
+	private void deleteExistingGenres(Member member) {
+		List<MemberFavorGenre> originalFavorGenres = memberFavorGenreRepository.findAllByMemberId(member.getId());
 
-        return new PutMemberNicknameResponse(member.getNickname());
-    }
+		if (!originalFavorGenres.isEmpty()) {
+			memberFavorGenreRepository.deleteAllByMemberId(member.getId());
+		}
+	}
 
-    @Override
-    public PutMemberNoticeResponse updateNotice(PutMemberNoticeRequest request) {
-        return null;
-    }
+	private List<String> saveNewGenres(PutMemberGenreListRequest request, Member member) {
+
+		return request.genres().stream()
+			.peek(genreName -> {
+				String genreCode = memberFavorGenreRepository.findGenreCodeByGenreName(genreName);
+
+				if (genreCode == null) {
+					throw memberGenreBadRequest(genreName);
+				}
+
+				MemberFavorGenre memberFavorGenre = MemberFavorGenre.builder()
+					.member(member)
+					.genreCode(genreCode)
+					.build();
+
+				memberFavorGenreRepository.save(memberFavorGenre);
+			}).collect(Collectors.toList());
+	}
+
+	@Override
+	public PutMemberImageResponse updateImage(PutMemberImageRequest request) {
+		return null;
+	}
+
+	@Override
+	@Transactional
+	public PutMemberNicknameResponse updateNickname(Member loginMember, PutMemberNicknameRequest request) {
+
+		Member member = memberRepository.findById(loginMember.getId())
+			.orElseThrow(() -> memberNotFound(loginMember.getId()));
+
+		if (memberRepository.existsByNickname(request.nickname())) {
+			throw nicknameDuplicate();
+		}
+
+		member.updateNickname(request.nickname());
+
+		return new PutMemberNicknameResponse(member.getNickname());
+	}
+
+	@Override
+	public PutMemberNoticeResponse updateNotice(PutMemberNoticeRequest request) {
+		return null;
+	}
 }

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -128,7 +128,6 @@ CREATE TABLE entry (
 
 CREATE TABLE member_favor_genre (
                                     genre_code varchar(2) null,
-                                    created_at datetime(6) null,
                                     id bigint auto_increment primary key,
                                     member_id binary(16) null,
                                     CONSTRAINT FKiaxiyt0n6b6l4v6lg57xmvfv4 FOREIGN KEY (member_id) REFERENCES member (id)


### PR DESCRIPTION
## PR 설명

- 회원 선호 장르 변경 구현
```
 1. 기존에 저장되어 있는 장르 코드 추출
 2. 요청된 선호 장르를 공통코드로 변환
 3. 기존 코드와 비교하여 겹치는 코드는 삭제, 겹치지 않는 코드는 추가
```

- Flyway V1 MemberFavorGenre 의 생성일시 제거

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/5619c393-7b88-48b0-ab89-88e2ebae9c67)


## 고민과 해결과정
