### PR TITLE
feat: accessToken 만료시 재발행하는 로직 추가

### DIFF
--- a/src/main/java/net/pointofviews/auth/config/GlobalSecurityConfig.java
+++ b/src/main/java/net/pointofviews/auth/config/GlobalSecurityConfig.java
@@ -1,5 +1,7 @@
 package net.pointofviews.auth.config;
 
+import net.pointofviews.auth.security.JwtAuthenticationFilter;
+import net.pointofviews.auth.security.JwtTokenFilter;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -21,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 public class GlobalSecurityConfig {
 
     private final CorsConfig cors;
+    private final JwtTokenFilter jwtTokenFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain globalSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -32,6 +37,8 @@ public class GlobalSecurityConfig {
                         .requestMatchers(ignoredRequests).permitAll()
                         .anyRequest().permitAll()
                 )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtTokenFilter, JwtAuthenticationFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
 

--- a/src/main/java/net/pointofviews/auth/controller/AuthController.java
+++ b/src/main/java/net/pointofviews/auth/controller/AuthController.java
@@ -51,9 +51,10 @@ public class AuthController implements AuthSpecification {
         // 회원이 존재하는 경우에만 토큰 생성 및 설정
         if (loginResponse.exists() && loginResponse.memberInfo() != null) {
             // 토큰 생성 (AT: 1시간, RT: 2주)
-            String accessToken = jwtProvider.createToken(loginResponse.memberInfo().id(), 3600000);
-            String refreshToken = jwtProvider.createToken(loginResponse.memberInfo().id(), 1209600000);
+            String accessToken = jwtProvider.createToken(loginResponse.memberInfo().id(), 60000);
+            String refreshToken = jwtProvider.createToken(loginResponse.memberInfo().id(), 300000);
 
+            // 1분 60000, 10초 10000
             // Access Token은 Authorization 헤더에 설정
             response.setHeader("Authorization", accessToken);
 

--- a/src/main/java/net/pointofviews/auth/controller/AuthSpecification.java
+++ b/src/main/java/net/pointofviews/auth/controller/AuthSpecification.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import net.pointofviews.auth.dto.request.CreateMemberRequest;
 import net.pointofviews.auth.dto.request.LoginMemberRequest;
+import net.pointofviews.auth.dto.response.CheckLoginResponse;
 import net.pointofviews.auth.dto.response.CreateMemberResponse;
 import net.pointofviews.auth.dto.response.LoginMemberResponse;
 import net.pointofviews.common.dto.BaseResponse;
@@ -18,12 +19,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface AuthSpecification {
-    // 회원가입
+    // 회원가입 (변경 사항 없음)
     @Tag(name = "Auth", description = "회원가입 관련 API")
     @Operation(summary = "회원가입", description = "💡새로운 회원을 등록하고 자동으로 로그인합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "⭕ CREATED"
-            ),
+            @ApiResponse(responseCode = "200", description = "⭕ CREATED"),
             @ApiResponse(responseCode = "400", description = "❌ BAD REQUEST",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(value = """
@@ -41,13 +41,40 @@ public interface AuthSpecification {
                     )
             )
     })
-    ResponseEntity<BaseResponse<LoginMemberResponse>> signup(@Valid @RequestBody CreateMemberRequest request, HttpServletResponse response);
+    ResponseEntity<BaseResponse<CheckLoginResponse>> signup(@Valid @RequestBody CreateMemberRequest request, HttpServletResponse response);
 
-    // 로그인
+    // 로그인 (수정 필요)
     @Tag(name = "Auth", description = "로그인 관련 API")
-    @Operation(summary = "로그인", description = "💡회원 로그인을 처리합니다.")
+    @Operation(summary = "로그인", description = "💡회원 로그인을 처리합니다. 회원이 없는 경우에도 200을 반환하며, exists 필드로 회원 존재 여부를 확인할 수 있습니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "⭕ SUCCESS"
+            @ApiResponse(responseCode = "200", description = "⭕ SUCCESS",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(name = "회원이 존재하는 경우", value = """
+                                    {
+                                      "message": "로그인이 완료되었습니다.",
+                                      "data": {
+                                        "exists": true,
+                                        "memberInfo": {
+                                          "id": "uuid",
+                                          "email": "user@example.com",
+                                          "nickname": "nickname",
+                                          "birth": "2000-01-01",
+                                          "favorGenres": ["로맨스", "코미디"],
+                                          "profileImage": "https://example.com/image.jpg",
+                                          "role": "USER"
+                                        }
+                                      }
+                                    }"""),
+                                    @ExampleObject(name = "회원이 존재하지 않는 경우", value = """
+                                    {
+                                      "message": "가입되지 않은 이메일입니다.",
+                                      "data": {
+                                        "exists": false,
+                                        "memberInfo": null
+                                      }
+                                    }""")
+                            })
             ),
             @ApiResponse(responseCode = "400", description = "❌ BAD REQUEST",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -56,15 +83,7 @@ public interface AuthSpecification {
                                   "message": "잘못된 소셜 로그인 타입입니다."
                                 }""")
                     )
-            ),
-            @ApiResponse(responseCode = "409", description = "❌ CONFLICT",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(value = """
-                                {
-                                  "message": "이미 존재하는 이메일입니다."
-                                }""")
-                    )
             )
     })
-    ResponseEntity<BaseResponse<LoginMemberResponse>> login(@Valid @RequestBody LoginMemberRequest request, HttpServletResponse response);
+    ResponseEntity<BaseResponse<CheckLoginResponse>> login(@Valid @RequestBody LoginMemberRequest request, HttpServletResponse response);
 }

--- a/src/main/java/net/pointofviews/auth/dto/response/CheckLoginResponse.java
+++ b/src/main/java/net/pointofviews/auth/dto/response/CheckLoginResponse.java
@@ -1,0 +1,12 @@
+package net.pointofviews.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 확인 응답 DTO")
+public record CheckLoginResponse(
+        @Schema(description = "회원 존재 여부")
+        boolean exists,
+
+        @Schema(description = "회원 정보 (존재하는 경우에만)")
+        LoginMemberResponse memberInfo
+) {}

--- a/src/main/java/net/pointofviews/auth/exception/SecurityException.java
+++ b/src/main/java/net/pointofviews/auth/exception/SecurityException.java
@@ -1,0 +1,18 @@
+package net.pointofviews.auth.exception;
+
+import net.pointofviews.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class SecurityException extends BusinessException {
+    public SecurityException(HttpStatus status, String message) {
+        super(status, message);
+    }
+
+    public static SecurityException tokenExpired() {
+        return new SecurityException(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+    }
+
+    public static SecurityException invalidToken() {
+        return new SecurityException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    }
+}

--- a/src/main/java/net/pointofviews/auth/security/JwtTokenFilter.java
+++ b/src/main/java/net/pointofviews/auth/security/JwtTokenFilter.java
@@ -1,0 +1,72 @@
+package net.pointofviews.auth.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.pointofviews.auth.utils.JwtProvider;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import net.pointofviews.auth.exception.SecurityException;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Order(1)
+@Slf4j
+public class JwtTokenFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessToken = request.getHeader("Authorization");
+        String refreshToken = extractRefreshTokenFromCookie(request.getCookies());
+
+        if (accessToken != null && refreshToken != null) {
+            try {
+                // AccessToken 만료 체크
+                if (jwtProvider.isTokenExpired(accessToken)) {
+                    // RefreshToken 만료 체크
+                    if (jwtProvider.isTokenExpired(refreshToken)) {
+                        log.info("at만료, rt 만료");
+                        throw SecurityException.tokenExpired();
+                    }
+                    // AccessToken 재발급
+                    String newAccessToken = jwtProvider.reissueAccessToken(refreshToken);
+                    request.setAttribute("access_token", newAccessToken);
+                    response.setHeader("Authorization", newAccessToken);
+                    log.info("at만료, rt 가능, at 헤더 추가");
+                }
+            } catch (Exception e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        }
+
+        if (response.getHeader("Authorization") != null) {
+            request.setAttribute("newAccessToken", response.getHeader("Authorization"));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractRefreshTokenFromCookie(Cookie[] cookies) {
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh-token".equals(cookie.getName())) {
+                    return cookie.getValue().replace("%20", " ");
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/pointofviews/member/service/MemberService.java
+++ b/src/main/java/net/pointofviews/member/service/MemberService.java
@@ -1,11 +1,11 @@
 package net.pointofviews.member.service;
 
+import net.pointofviews.auth.dto.response.CheckLoginResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import net.pointofviews.auth.dto.request.CreateMemberRequest;
 import net.pointofviews.auth.dto.request.LoginMemberRequest;
 import net.pointofviews.auth.dto.response.CreateMemberResponse;
-import net.pointofviews.auth.dto.response.LoginMemberResponse;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.dto.request.*;
 import net.pointofviews.member.dto.response.*;
@@ -13,7 +13,7 @@ import net.pointofviews.member.dto.response.*;
 public interface MemberService {
     CreateMemberResponse signup(CreateMemberRequest request);
 
-    LoginMemberResponse login(LoginMemberRequest request);
+    CheckLoginResponse login(LoginMemberRequest request);
 
     void deleteMember(Member loginMember);
 


### PR DESCRIPTION
## PR 설명
- 신규회원 로그인시 404 -> 200 으로 수정
- at 만료시 rt 확인 후 at 재발행 현재 at:1분, rt:5분으로 설정 (추후 변경 필요)

## 📸 스크린샷
![스크린샷 2024-12-07 오후 4 32 16](https://github.com/user-attachments/assets/3b29abda-92bd-41cd-88be-8d38e0473d95)
![스크린샷 2024-12-07 오후 4 35 43](https://github.com/user-attachments/assets/31f6a0ac-948c-4607-8e0e-cfedb08b60da)


## 고민과 해결과정
