### PR TITLE
feat: 클럽 상세 조회, 검색 및 테스트 코드 구현

### DIFF
--- a/src/main/java/net/pointofviews/club/controller/ClubController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubController.java
@@ -35,6 +35,14 @@ public class ClubController implements ClubSpecification {
         return BaseResponse.ok("공개된 모든 클럽이 성공적으로 조회되었습니다.", response);
     }
 
+    @GetMapping("/search")
+    @Override
+    public ResponseEntity<BaseResponse<SearchClubsListResponse>> searchClubs(@RequestParam String query,
+                                                                              Pageable pageable) {
+        SearchClubsListResponse response = clubService.searchClubs(query, pageable);
+        return BaseResponse.ok("공개된 모든 클럽이 성공적으로 조회되었습니다.", response);
+    }
+
     @GetMapping("/{clubId}")
     @Override
     public ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(@PathVariable UUID clubId, @AuthenticationPrincipal(expression = "member") Member loginMember, Pageable pageable) {

--- a/src/main/java/net/pointofviews/club/controller/ClubController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubController.java
@@ -7,6 +7,7 @@ import net.pointofviews.club.controller.specification.ClubSpecification;
 import net.pointofviews.club.dto.request.CreateClubRequest;
 import net.pointofviews.club.dto.response.*;
 import net.pointofviews.club.dto.request.*;
+import net.pointofviews.club.service.ClubSearchService;
 import net.pointofviews.club.service.ClubService;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.member.domain.Member;
@@ -27,6 +28,7 @@ import java.util.UUID;
 public class ClubController implements ClubSpecification {
 
     private final ClubService clubService;
+    private final ClubSearchService clubSearchService;
 
     @GetMapping
     @Override
@@ -39,8 +41,8 @@ public class ClubController implements ClubSpecification {
     @Override
     public ResponseEntity<BaseResponse<SearchClubsListResponse>> searchClubs(@RequestParam String query,
                                                                               Pageable pageable) {
-        SearchClubsListResponse response = clubService.searchClubs(query, pageable);
-        return BaseResponse.ok("공개된 모든 클럽이 성공적으로 조회되었습니다.", response);
+        SearchClubsListResponse response = clubSearchService.searchClubs(query, pageable);
+        return BaseResponse.ok("공개된 모든 클럽이 성공적으로 검색되었습니다.", response);
     }
 
     @GetMapping("/{clubId}")

--- a/src/main/java/net/pointofviews/club/controller/ClubController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubController.java
@@ -3,6 +3,7 @@ package net.pointofviews.club.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.pointofviews.auth.dto.MemberDetailsDto;
+import net.pointofviews.club.controller.specification.ClubSpecification;
 import net.pointofviews.club.dto.request.CreateClubRequest;
 import net.pointofviews.club.dto.response.*;
 import net.pointofviews.club.dto.request.*;
@@ -23,7 +24,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/clubs")
 @RequiredArgsConstructor
-public class ClubController implements ClubSpecification{
+public class ClubController implements ClubSpecification {
 
     private final ClubService clubService;
 
@@ -46,12 +47,6 @@ public class ClubController implements ClubSpecification{
     public ResponseEntity<BaseResponse<ReadAllClubsListResponse>> readAllMyClubs(@AuthenticationPrincipal(expression = "member") Member loginMember) {
         ReadAllClubsListResponse response = clubService.readAllMyClubs(loginMember);
         return BaseResponse.ok("사용자가 속한 모든 클럽이 성공적으로 조회되었습니다.", response);
-    }
-
-    @GetMapping("/{clubId}/bookmark")
-    @Override
-    public ResponseEntity<BaseResponse<ReadClubMoviesListResponse>> readMyClubMovies(@AuthenticationPrincipal MemberDetailsDto memberDetailsDto) {
-        return null;
     }
 
     @PostMapping

--- a/src/main/java/net/pointofviews/club/controller/ClubController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubController.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Pageable;
+
 
 import java.util.List;
 import java.util.UUID;
@@ -34,8 +36,8 @@ public class ClubController implements ClubSpecification{
 
     @GetMapping("/{clubId}")
     @Override
-    public ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(@PathVariable UUID clubId, @AuthenticationPrincipal(expression = "member") Member loginMember) {
-        ReadClubDetailsResponse response = clubService.readClubDetails(clubId, loginMember);
+    public ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(@PathVariable UUID clubId, @AuthenticationPrincipal(expression = "member") Member loginMember, Pageable pageable) {
+        ReadClubDetailsResponse response = clubService.readClubDetails(clubId, loginMember,pageable);
         return BaseResponse.ok("클럽 상세 정보를 성공적으로 조회했습니다.", response);
     }
 

--- a/src/main/java/net/pointofviews/club/controller/ClubMovieController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubMovieController.java
@@ -1,0 +1,33 @@
+package net.pointofviews.club.controller;
+
+import lombok.RequiredArgsConstructor;
+import net.pointofviews.club.controller.specification.ClubMovieSpecification;
+import net.pointofviews.club.dto.response.*;
+import net.pointofviews.club.service.ClubMovieService;
+import net.pointofviews.common.dto.BaseResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/clubs")
+@RequiredArgsConstructor
+public class ClubMovieController implements ClubMovieSpecification {
+
+    private final ClubMovieService clubMovieService;
+
+    @GetMapping("/{clubId}/bookmark")
+    @Override
+    public ResponseEntity<BaseResponse<ReadClubMoviesListResponse>> readMyClubMovies(@PathVariable UUID clubId, @PageableDefault Pageable pageable) {
+        ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, pageable);
+
+        if (response.clubMovies().isEmpty()) {
+            return BaseResponse.noContent();
+        }
+
+        return BaseResponse.ok("클럽 별 영화 북마크가 성공적으로 조회되었습니다.", response);
+    }
+}

--- a/src/main/java/net/pointofviews/club/controller/ClubSpecification.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubSpecification.java
@@ -11,9 +11,7 @@ import net.pointofviews.auth.dto.MemberDetailsDto;
 import net.pointofviews.club.dto.request.*;
 import net.pointofviews.club.dto.response.*;
 import net.pointofviews.common.dto.BaseResponse;
-import net.pointofviews.curation.dto.response.ReadCurationListResponse;
 import net.pointofviews.member.domain.Member;
-import net.pointofviews.review.dto.response.CreateReviewImageListResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +19,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Pageable;
+
 
 import java.util.List;
 import java.util.UUID;
@@ -58,7 +58,8 @@ public interface ClubSpecification {
     })
     ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(
             @PathVariable UUID clubId,
-            @AuthenticationPrincipal(expression = "member") Member loginMember
+            @AuthenticationPrincipal(expression = "member") Member loginMember,
+            Pageable pageable
     );
 
     @Operation(summary = "내 그룹 조회", description = "사용자가 속한 모든 클럽 정보를 조회합니다.")

--- a/src/main/java/net/pointofviews/club/controller/specification/ClubMovieSpecification.java
+++ b/src/main/java/net/pointofviews/club/controller/specification/ClubMovieSpecification.java
@@ -1,0 +1,32 @@
+package net.pointofviews.club.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import net.pointofviews.club.dto.response.*;
+import net.pointofviews.common.dto.BaseResponse;
+import net.pointofviews.member.domain.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@Tag(name = "Club", description = "클럽 영화 북마크 관련 API")
+public interface ClubMovieSpecification {
+
+    @Operation(summary = "클럽 영화 북마크 조회", description = "클럽에서 저장한 영화 리스트를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"
+            )
+    })
+    ResponseEntity<BaseResponse<ReadClubMoviesListResponse>> readMyClubMovies(
+            @PathVariable UUID clubId,
+            @PageableDefault Pageable pageable);
+
+}

--- a/src/main/java/net/pointofviews/club/controller/specification/ClubSpecification.java
+++ b/src/main/java/net/pointofviews/club/controller/specification/ClubSpecification.java
@@ -1,4 +1,4 @@
-package net.pointofviews.club.controller;
+package net.pointofviews.club.controller.specification;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -70,15 +70,6 @@ public interface ClubSpecification {
             )
     })
     ResponseEntity<BaseResponse<ReadAllClubsListResponse>> readAllMyClubs(@AuthenticationPrincipal(expression = "member") Member loginMember);
-
-    @Operation(summary = "클럽 영화 북마크 조회", description = "클럽에서 저장한 영화 리스트를 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공"
-            )
-    })
-    ResponseEntity<BaseResponse<ReadClubMoviesListResponse>> readMyClubMovies(@AuthenticationPrincipal MemberDetailsDto memberDetailsDto);
 
     @Operation(summary = "클럽 생성", description = "새로운 클럽을 생성합니다.")
     @ApiResponses(value = {

--- a/src/main/java/net/pointofviews/club/controller/specification/ClubSpecification.java
+++ b/src/main/java/net/pointofviews/club/controller/specification/ClubSpecification.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +37,18 @@ public interface ClubSpecification {
             )
     })
     ResponseEntity<BaseResponse<ReadAllClubsListResponse>> readAllClubs();
+
+    @Operation(summary = "그룹 검색", description = "클럽을 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "검색 성공"
+            )
+    })
+    ResponseEntity<BaseResponse<SearchClubsListResponse>> searchClubs(
+            @RequestParam String query,
+            Pageable pageable
+    );
 
     @Operation(summary = "클럽 상세 조회", description = "특정 클럽의 상세 정보를 조회합니다.")
     @ApiResponses({

--- a/src/main/java/net/pointofviews/club/dto/response/FindBasicClubInfo.java
+++ b/src/main/java/net/pointofviews/club/dto/response/FindBasicClubInfo.java
@@ -1,0 +1,24 @@
+package net.pointofviews.club.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "클럽 기본 정보 DTO")
+public record FindBasicClubInfo(
+        @Schema(description = "클럽 이름", example = "00즈")
+        String name,
+
+        @Schema(description = "클럽 설명", example = "영화를 좋아하는 00년생들")
+        String description,
+
+        @Schema(description = "클럽 대표 이미지", example = "https://example.com/image.jpg")
+        String image,
+
+        @Schema(description = "클럽 공개 여부", example = "true")
+        boolean isPublic,
+
+        @Schema(description = "참가자 수", example = "3")
+        Long participant,
+
+        @Schema(description = "이 클럽의 북마크 수", example = "5")
+        Long movieCount
+) {}

--- a/src/main/java/net/pointofviews/club/dto/response/ReadClubDetailsResponse.java
+++ b/src/main/java/net/pointofviews/club/dto/response/ReadClubDetailsResponse.java
@@ -24,7 +24,7 @@ public record ReadClubDetailsResponse(
         ReadClubMemberListResponse members,
 
         @Schema(description = "참가자 수", example = "3")
-        int participant,
+        Long participant,
 
         @Schema(description = "클럽 공개 여부", example = "true")
         boolean isPublic,
@@ -32,7 +32,13 @@ public record ReadClubDetailsResponse(
         @Schema(description = "클럽원들이 작성한 리뷰")
         ReadMyClubReviewListResponse clubReviewList,
 
+        @Schema(description = "클럽원들이 작성한 리뷰 수", example = "15")
+        int reviewCount,
+
         @Schema(description = "이 클럽의 북마크")
-        ReadClubMoviesListResponse clubMovieList
+        ReadClubMoviesListResponse clubMovieList,
+
+        @Schema(description = "이 클럽의 북마크 수", example = "5")
+        Long movieCount
 
 ) {}

--- a/src/main/java/net/pointofviews/club/dto/response/ReadClubMovieResponse.java
+++ b/src/main/java/net/pointofviews/club/dto/response/ReadClubMovieResponse.java
@@ -2,6 +2,8 @@ package net.pointofviews.club.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+
 @Schema(description = "클럽별 영화 북마크 정보 응답 DTO")
 public record ReadClubMovieResponse(
         @Schema(description = "영화 제목", example = "Inception")
@@ -11,11 +13,19 @@ public record ReadClubMovieResponse(
         String poster,
 
         @Schema(description = "출시일", example = "2010-07-16", format = "date")
-        int released,
+        LocalDate released,
 
         @Schema(description = "영화 좋아요 수", example = "156")
-        int movieLikeCount,
+        Long movieLikeCount,
 
-        @Schema(description = "영화 리뷰 수", example = "156")
-        int movieReviewCount
-) {}
+        @Schema(description = "영화 리뷰 수", example = "15")
+        Long movieReviewCount
+) {
+        public ReadClubMovieResponse(String title, String poster, LocalDate released, Long movieLikeCount, Long movieReviewCount) {
+                this.title = title;
+                this.poster = poster;
+                this.released = released;
+                this.movieLikeCount = movieLikeCount != null ? movieLikeCount : 0; // Null 처리
+                this.movieReviewCount = movieReviewCount != null ? movieReviewCount : 0; // Null 처리
+        }
+}

--- a/src/main/java/net/pointofviews/club/dto/response/ReadClubMoviesListResponse.java
+++ b/src/main/java/net/pointofviews/club/dto/response/ReadClubMoviesListResponse.java
@@ -1,11 +1,10 @@
 package net.pointofviews.club.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.util.List;
+import org.springframework.data.domain.Slice;
 
 @Schema(description = "클럽 북마크 영화 전체 리스트 응답 DTO")
 public record ReadClubMoviesListResponse(
         @Schema(description = "클럽 북마크 영화 리스트")
-        List<ReadClubMovieResponse> clubMovies
+        Slice<ReadClubMovieResponse> clubMovies
 ) {}

--- a/src/main/java/net/pointofviews/club/dto/response/SearchClubsListResponse.java
+++ b/src/main/java/net/pointofviews/club/dto/response/SearchClubsListResponse.java
@@ -1,0 +1,10 @@
+package net.pointofviews.club.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
+
+@Schema(description = "클럽 검색 리스트 응답 DTO")
+public record SearchClubsListResponse(
+        @Schema(description = "클럽 리스트")
+        Slice<ReadAllClubsResponse> clubs
+) {}

--- a/src/main/java/net/pointofviews/club/dto/response/SearchClubsListResponse.java
+++ b/src/main/java/net/pointofviews/club/dto/response/SearchClubsListResponse.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Slice;
 @Schema(description = "클럽 검색 리스트 응답 DTO")
 public record SearchClubsListResponse(
         @Schema(description = "클럽 리스트")
-        Slice<ReadAllClubsResponse> clubs
+        Slice<SearchClubsResponse> clubs
 ) {}

--- a/src/main/java/net/pointofviews/club/dto/response/SearchClubsResponse.java
+++ b/src/main/java/net/pointofviews/club/dto/response/SearchClubsResponse.java
@@ -1,0 +1,30 @@
+package net.pointofviews.club.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "클럽 검색 응답 DTO")
+public record SearchClubsResponse(
+        @Schema(description = "클럽 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+        UUID clubId,
+
+        @Schema(description = "클럽 이름", example = "화양동 민음사 북클럽")
+        String clubName,
+
+        @Schema(description = "클럽 설명", example = "화양동에는 딱 한명만 사는 화양동 민음사 북클럽📚")
+        String clubDescription,
+
+        @Schema(description = "참가자 수", example = "3")
+        int participant,
+
+        @Schema(description = "최대 참가자 수", example = "100")
+        int maxParticipant,
+
+        @Schema(description = "북마크 개수", example = "5")
+        int clubMovieCount,
+
+        @Schema(description = "클럽 선호 장르 해시태그", example = "[액션, SF]")
+        List<String> clubFavorGenres
+) {}

--- a/src/main/java/net/pointofviews/club/exception/ClubException.java
+++ b/src/main/java/net/pointofviews/club/exception/ClubException.java
@@ -27,7 +27,7 @@ public class ClubException extends BusinessException {
         return new ClubException(HttpStatus.BAD_REQUEST, "클럽장은 클럽을 탈퇴할 수 없습니다.");
     }
 
-    public static ClubException ClubLeaderNotFoundException() {
-        return new ClubException(HttpStatus.INTERNAL_SERVER_ERROR, "클럽 리더가 설정되지 않았습니다.");
+    public static ClubException clubLeaderNotFound(UUID clubId) {
+        return new ClubException(HttpStatus.NOT_FOUND, String.format("클럽(ID: %s)의 리더를 찾을 수 없습니다.", clubId));
     }
 }

--- a/src/main/java/net/pointofviews/club/repository/ClubFavorGenreRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/ClubFavorGenreRepository.java
@@ -3,11 +3,22 @@ package net.pointofviews.club.repository;
 import net.pointofviews.club.domain.Club;
 import net.pointofviews.club.domain.ClubFavorGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface ClubFavorGenreRepository extends JpaRepository<ClubFavorGenre, Long> {
     List<ClubFavorGenre> findAllByClub(Club club);
 
     void deleteAllByClub(Club club);
+
+    @Query("""
+       SELECT cfg.genreCode
+       FROM ClubFavorGenre cfg
+       WHERE cfg.club.id = :clubId
+       """)
+    List<String> findGenresByClubId(@Param("clubId") UUID clubId);
+
 }

--- a/src/main/java/net/pointofviews/club/repository/ClubMoviesRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/ClubMoviesRepository.java
@@ -2,11 +2,13 @@ package net.pointofviews.club.repository;
 
 import net.pointofviews.club.domain.ClubMovie;
 import net.pointofviews.club.dto.response.ReadClubMovieResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface ClubMoviesRepository extends JpaRepository<ClubMovie, Long> {
@@ -25,5 +27,5 @@ public interface ClubMoviesRepository extends JpaRepository<ClubMovie, Long> {
        WHERE cm.club.id = :clubId
        GROUP BY m.id, m.title, m.poster, m.released, mlc.likeCount
        """)
-    List<ReadClubMovieResponse> findMovieDetailsByClubId(@Param("clubId") UUID clubId);
+    Slice<ReadClubMovieResponse> findMovieDetailsByClubId(@Param("clubId") UUID clubId,  Pageable pageable);
 }

--- a/src/main/java/net/pointofviews/club/repository/ClubMoviesRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/ClubMoviesRepository.java
@@ -1,0 +1,29 @@
+package net.pointofviews.club.repository;
+
+import net.pointofviews.club.domain.ClubMovie;
+import net.pointofviews.club.dto.response.ReadClubMovieResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ClubMoviesRepository extends JpaRepository<ClubMovie, Long> {
+    @Query("""
+       SELECT new net.pointofviews.club.dto.response.ReadClubMovieResponse(
+           m.title,
+           m.poster,
+           m.released,
+           COALESCE(mlc.likeCount, 0) AS movieLikeCount,
+           COUNT(r.id) AS movieReviewCount
+       )
+       FROM ClubMovie cm
+       JOIN cm.movie m
+       LEFT JOIN m.reviews r
+       LEFT JOIN MovieLikeCount mlc ON mlc.movie.id = m.id
+       WHERE cm.club.id = :clubId
+       GROUP BY m.id, m.title, m.poster, m.released, mlc.likeCount
+       """)
+    List<ReadClubMovieResponse> findMovieDetailsByClubId(@Param("clubId") UUID clubId);
+}

--- a/src/main/java/net/pointofviews/club/repository/ClubRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/ClubRepository.java
@@ -1,5 +1,6 @@
 package net.pointofviews.club.repository;
 
+import net.pointofviews.club.dto.response.FindBasicClubInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.pointofviews.club.domain.Club;
@@ -41,14 +42,19 @@ public interface ClubRepository extends JpaRepository<Club, UUID> {
     List<Object[]> findAllPublicClubs();
 
     @Query("""
-           SELECT c
-           FROM Club c
-           LEFT JOIN FETCH c.memberClubs mc
-           LEFT JOIN FETCH c.clubMovies cm
-           LEFT JOIN FETCH c.clubFavorGenres cfg
-           WHERE c.id = :clubId
-           """)
-    Optional<Club> findByIdWithDetails(@Param("clubId") UUID clubId);
-
+       SELECT new net.pointofviews.club.dto.response.FindBasicClubInfo(
+           c.name,
+           c.description,
+           c.clubImage,
+           c.isPublic,
+           COUNT(DISTINCT mc.id),
+           COUNT(DISTINCT cm.id)
+       )
+       FROM Club c
+       LEFT JOIN c.memberClubs mc
+       LEFT JOIN c.clubMovies cm
+       WHERE c.id = :clubId
+       """)
+    Optional<FindBasicClubInfo> findBasicClubInfoById(@Param("clubId") UUID clubId);
 
 }

--- a/src/main/java/net/pointofviews/club/repository/ClubRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/ClubRepository.java
@@ -1,6 +1,8 @@
 package net.pointofviews.club.repository;
 
 import net.pointofviews.club.dto.response.FindBasicClubInfo;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.pointofviews.club.domain.Club;
@@ -57,4 +59,32 @@ public interface ClubRepository extends JpaRepository<Club, UUID> {
        """)
     Optional<FindBasicClubInfo> findBasicClubInfoById(@Param("clubId") UUID clubId);
 
+
+    /**
+     * 검색
+     */
+    @Query(value = """
+    SELECT DISTINCT BIN_TO_UUID(c.id) AS clubId, c.name AS clubName, c.description AS clubDescription,
+           COUNT(DISTINCT mc.id) AS participantCount,
+           c.max_participants AS maxParticipant,
+           COUNT(DISTINCT cm.id) AS clubMovieCount,
+           COALESCE(GROUP_CONCAT(DISTINCT cfg.genre_code), '') AS clubFavorGenres
+    FROM club c
+    LEFT JOIN member_club mc ON mc.club_id = c.id
+    LEFT JOIN club_movie cm ON cm.club_id = c.id
+    LEFT JOIN club_favor_genre cfg ON cfg.club_id = c.id
+    LEFT JOIN member m ON m.id = mc.member_id
+    WHERE MATCH(c.name) AGAINST(:query IN NATURAL LANGUAGE MODE)
+       OR EXISTS (
+           SELECT 1
+           FROM member_club mc2
+           JOIN member m2 ON m2.id = mc2.member_id
+           WHERE mc2.club_id = c.id
+             AND MATCH(m2.nickname) AGAINST(:query IN NATURAL LANGUAGE MODE)
+             AND mc2.is_leader = TRUE
+       )
+    GROUP BY c.id
+    """,
+            nativeQuery = true)
+    Slice<Object[]> searchClubsByTitleOrNickname(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/net/pointofviews/club/repository/MemberClubRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/MemberClubRepository.java
@@ -2,6 +2,7 @@ package net.pointofviews.club.repository;
 
 import net.pointofviews.club.domain.Club;
 import net.pointofviews.club.domain.MemberClub;
+import net.pointofviews.club.dto.response.ReadClubMemberResponse;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.review.dto.response.ReadReviewResponse;
 import org.springframework.data.domain.Pageable;
@@ -72,4 +73,33 @@ public interface MemberClubRepository extends JpaRepository<MemberClub, Long> {
            """)
     List<Object[]> findMyClubsByMemberId(@Param("memberId") UUID memberId);
 
+    @Query("""
+       SELECT new net.pointofviews.club.dto.response.ReadClubMemberResponse(
+           m.nickname,
+           m.profileImage,
+           mc.isLeader
+       )
+       FROM MemberClub mc
+       JOIN mc.member m
+       WHERE mc.club.id = :clubId
+       """)
+    List<ReadClubMemberResponse> findMembersByClubId(@Param("clubId") UUID clubId);
+
+    @Query("""
+       SELECT mc
+       FROM MemberClub mc
+       WHERE mc.club.id = :clubId AND mc.member.id = :memberId
+       """)
+    Optional<MemberClub> findByClubIdAndMemberId(@Param("clubId") UUID clubId, @Param("memberId") UUID memberId);
+
+    @Query("""
+       SELECT new net.pointofviews.club.dto.response.ReadClubMemberResponse(
+           mc.member.nickname,
+           mc.member.profileImage,
+           mc.isLeader
+       )
+       FROM MemberClub mc
+       WHERE mc.club.id = :clubId AND mc.isLeader = true
+       """)
+    Optional<ReadClubMemberResponse> findLeaderByClubId(@Param("clubId") UUID clubId);
 }

--- a/src/main/java/net/pointofviews/club/service/ClubFavorGenreService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubFavorGenreService.java
@@ -1,0 +1,8 @@
+package net.pointofviews.club.service;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ClubFavorGenreService {
+    List<String> readGenreNamesByClubId(UUID clubId);
+}

--- a/src/main/java/net/pointofviews/club/service/ClubMovieService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubMovieService.java
@@ -1,0 +1,9 @@
+package net.pointofviews.club.service;
+
+import net.pointofviews.club.dto.response.ReadClubMoviesListResponse;
+
+import java.util.UUID;
+
+public interface ClubMovieService {
+    ReadClubMoviesListResponse readClubMovies(UUID clubId);
+}

--- a/src/main/java/net/pointofviews/club/service/ClubMovieService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubMovieService.java
@@ -1,9 +1,10 @@
 package net.pointofviews.club.service;
 
 import net.pointofviews.club.dto.response.ReadClubMoviesListResponse;
+import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
 public interface ClubMovieService {
-    ReadClubMoviesListResponse readClubMovies(UUID clubId);
+    ReadClubMoviesListResponse readClubMovies(UUID clubId, Pageable pageable);
 }

--- a/src/main/java/net/pointofviews/club/service/ClubSearchService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubSearchService.java
@@ -1,0 +1,8 @@
+package net.pointofviews.club.service;
+
+import net.pointofviews.club.dto.response.SearchClubsListResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface ClubSearchService {
+    SearchClubsListResponse searchClubs(String query, Pageable pageable);
+}

--- a/src/main/java/net/pointofviews/club/service/ClubService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubService.java
@@ -30,8 +30,6 @@ public interface ClubService {
 
     ReadAllClubsListResponse readAllPublicClubs();
 
-    SearchClubsListResponse searchClubs(String query, Pageable pageable);
-
     ReadAllClubsListResponse readAllMyClubs(Member loginMember);
 
     ReadClubDetailsResponse readClubDetails(UUID clubId, Member loginMember, Pageable pageable);

--- a/src/main/java/net/pointofviews/club/service/ClubService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubService.java
@@ -6,8 +6,9 @@ import net.pointofviews.club.dto.request.PutClubLeaderRequest;
 import net.pointofviews.club.dto.request.PutClubRequest;
 import net.pointofviews.club.dto.response.*;
 import net.pointofviews.member.domain.Member;
-import org.springframework.data.repository.query.Param;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Pageable;
+
 
 import java.util.List;
 import java.util.UUID;
@@ -31,7 +32,6 @@ public interface ClubService {
 
     ReadAllClubsListResponse readAllMyClubs(Member loginMember);
 
-    ReadClubDetailsResponse readClubDetails(UUID clubId, Member loginMember);
+    ReadClubDetailsResponse readClubDetails(UUID clubId, Member loginMember, Pageable pageable);
 
-    ReadClubMoviesListResponse readMyClubMovies();
 }

--- a/src/main/java/net/pointofviews/club/service/ClubService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubService.java
@@ -30,6 +30,8 @@ public interface ClubService {
 
     ReadAllClubsListResponse readAllPublicClubs();
 
+    SearchClubsListResponse searchClubs(String query, Pageable pageable);
+
     ReadAllClubsListResponse readAllMyClubs(Member loginMember);
 
     ReadClubDetailsResponse readClubDetails(UUID clubId, Member loginMember, Pageable pageable);

--- a/src/main/java/net/pointofviews/club/service/MemberClubService.java
+++ b/src/main/java/net/pointofviews/club/service/MemberClubService.java
@@ -1,0 +1,13 @@
+package net.pointofviews.club.service;
+
+import net.pointofviews.club.dto.response.ReadClubMemberListResponse;
+import net.pointofviews.club.dto.response.ReadClubMemberResponse;
+
+import java.util.UUID;
+
+public interface MemberClubService {
+    ReadClubMemberListResponse readMembersByClubId(UUID clubId);
+
+    boolean isMemberOfClub(UUID clubId, UUID memberId);
+    ReadClubMemberResponse readClubLeaderByClubId(UUID clubId);
+}

--- a/src/main/java/net/pointofviews/club/service/impl/ClubFavorGenreServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubFavorGenreServiceImpl.java
@@ -1,0 +1,34 @@
+package net.pointofviews.club.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import net.pointofviews.club.repository.ClubFavorGenreRepository;
+import net.pointofviews.club.service.ClubFavorGenreService;
+import net.pointofviews.common.domain.CodeGroupEnum;
+import net.pointofviews.common.service.CommonCodeService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubFavorGenreServiceImpl implements ClubFavorGenreService {
+
+    private final ClubFavorGenreRepository clubFavorGenreRepository;
+    private final CommonCodeService commonCodeService;
+
+    @Override
+    public List<String> readGenreNamesByClubId(UUID clubId) {
+        // 클럽의 장르 코드 조회
+        List<String> genreCodes = clubFavorGenreRepository.findGenresByClubId(clubId);
+
+        // 코드 -> 이름 변환
+        return genreCodes.stream()
+                .map(code -> commonCodeService.convertCommonCodeToName(code, CodeGroupEnum.MOVIE_GENRE))
+                .collect(Collectors.toList());
+
+    }
+}

--- a/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
@@ -5,6 +5,8 @@ import net.pointofviews.club.dto.response.ReadClubMovieResponse;
 import net.pointofviews.club.dto.response.ReadClubMoviesListResponse;
 import net.pointofviews.club.repository.ClubMoviesRepository;
 import net.pointofviews.club.service.ClubMovieService;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +21,8 @@ public class ClubMovieServiceImpl implements ClubMovieService {
     private final ClubMoviesRepository clubMoviesRepository;
 
     @Override
-    public ReadClubMoviesListResponse readClubMovies(UUID clubId) {
-        List<ReadClubMovieResponse> movies = clubMoviesRepository.findMovieDetailsByClubId(clubId);
+    public ReadClubMoviesListResponse readClubMovies(UUID clubId, Pageable pageable) {
+        Slice<ReadClubMovieResponse> movies = clubMoviesRepository.findMovieDetailsByClubId(clubId,pageable);
         return new ReadClubMoviesListResponse(movies);
     }
 }

--- a/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service

--- a/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
@@ -1,0 +1,26 @@
+package net.pointofviews.club.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import net.pointofviews.club.dto.response.ReadClubMovieResponse;
+import net.pointofviews.club.dto.response.ReadClubMoviesListResponse;
+import net.pointofviews.club.repository.ClubMoviesRepository;
+import net.pointofviews.club.service.ClubMovieService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubMovieServiceImpl implements ClubMovieService {
+
+    private final ClubMoviesRepository clubMoviesRepository;
+
+    @Override
+    public ReadClubMoviesListResponse readClubMovies(UUID clubId) {
+        List<ReadClubMovieResponse> movies = clubMoviesRepository.findMovieDetailsByClubId(clubId);
+        return new ReadClubMoviesListResponse(movies);
+    }
+}

--- a/src/main/java/net/pointofviews/club/service/impl/ClubSearchServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubSearchServiceImpl.java
@@ -1,0 +1,85 @@
+package net.pointofviews.club.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.pointofviews.club.domain.Club;
+import net.pointofviews.club.domain.ClubFavorGenre;
+import net.pointofviews.club.domain.MemberClub;
+import net.pointofviews.club.dto.request.CreateClubRequest;
+import net.pointofviews.club.dto.request.PutClubLeaderRequest;
+import net.pointofviews.club.dto.request.PutClubRequest;
+import net.pointofviews.club.dto.response.*;
+import net.pointofviews.club.exception.ClubException;
+import net.pointofviews.club.repository.ClubFavorGenreRepository;
+import net.pointofviews.club.repository.ClubRepository;
+import net.pointofviews.club.repository.MemberClubRepository;
+import net.pointofviews.club.service.*;
+import net.pointofviews.common.domain.CodeGroupEnum;
+import net.pointofviews.common.service.CommonCodeService;
+import net.pointofviews.common.service.S3Service;
+import net.pointofviews.member.domain.Member;
+import net.pointofviews.member.exception.MemberException;
+import net.pointofviews.member.repository.MemberRepository;
+import net.pointofviews.movie.dto.response.SearchMovieListResponse;
+import net.pointofviews.movie.dto.response.SearchMovieResponse;
+import net.pointofviews.review.dto.response.ReadMyClubReviewListResponse;
+import net.pointofviews.review.service.ReviewClubService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static net.pointofviews.club.exception.ClubException.clubNotFound;
+import static net.pointofviews.common.exception.S3Exception.invalidTotalImageSize;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubSearchServiceImpl implements ClubSearchService {
+
+    private final ClubRepository clubRepository;
+    private final CommonCodeService commonCodeService;
+
+
+    @Override
+    public SearchClubsListResponse searchClubs(String query, Pageable pageable) {
+
+        Slice<SearchClubsResponse> responses = clubRepository.searchClubsByTitleOrNickname(query, pageable)
+                .map(row -> {
+                    UUID clubId = UUID.fromString((String) row[0]);
+                    String clubName = (String) row[1];
+                    String clubDescription = (String) row[2];
+                    int participant = ((Number) row[3]).intValue();
+                    int maxParticipant = ((Number) row[4]).intValue();
+                    int clubMovieCount = ((Number) row[5]).intValue();
+
+                    // 장르 코드를 이름으로 변환
+                    String genreCodeString = (String) row[6];
+                    List<String> genreNames = convertGenreCodesToNames(List.of(genreCodeString.split(",")));
+
+                    return new SearchClubsResponse(
+                            clubId,
+                            clubName,
+                            clubDescription,
+                            participant,
+                            maxParticipant,
+                            clubMovieCount,
+                            genreNames
+                    );
+                });
+
+        return new SearchClubsListResponse(responses);
+    }
+
+    public List<String> convertGenreCodesToNames(List<String> genreCodes) {
+        return genreCodes.stream()
+                .map(code -> commonCodeService.convertCommonCodeToName(code, CodeGroupEnum.MOVIE_GENRE))
+                .toList();
+    }
+
+}

--- a/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
@@ -400,6 +400,8 @@ public class ClubServiceImpl implements ClubService {
             ReadMyClubReviewListResponse reviews = reviewClubService.findReviewByClub(clubId, pageable);
             ReadClubMoviesListResponse bookmarks = clubMovieService.readClubMovies(clubId, pageable);
 
+            int reviewCount = reviews != null ? reviews.reviews().getSize() : 0;
+
             return new ReadClubDetailsResponse(
                     basicInfo.name(),
                     basicInfo.description(),
@@ -409,7 +411,7 @@ public class ClubServiceImpl implements ClubService {
                     basicInfo.participant(),
                     basicInfo.isPublic(),
                     reviews,
-                    reviews.reviews().getSize(), // 리뷰 수
+                    reviewCount,
                     bookmarks,
                     basicInfo.movieCount()
             );

--- a/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
@@ -343,11 +343,6 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public SearchClubsListResponse searchClubs(String query, Pageable pageable) {
-        return null;
-    }
-
-    @Override
     public ReadAllClubsListResponse readAllMyClubs(Member loginMember) {
         UUID memberId = loginMember.getId();
         List<Object[]> clubData = memberClubRepository.findMyClubsByMemberId(memberId);

--- a/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
@@ -343,6 +343,11 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
+    public SearchClubsListResponse searchClubs(String query, Pageable pageable) {
+        return null;
+    }
+
+    @Override
     public ReadAllClubsListResponse readAllMyClubs(Member loginMember) {
         UUID memberId = loginMember.getId();
         List<Object[]> clubData = memberClubRepository.findMyClubsByMemberId(memberId);

--- a/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
@@ -393,7 +393,7 @@ public class ClubServiceImpl implements ClubService {
 
             ReadClubMemberListResponse members = memberClubService.readMembersByClubId(clubId);
             ReadMyClubReviewListResponse reviews = reviewClubService.findReviewByClub(clubId, pageable);
-            ReadClubMoviesListResponse bookmarks = clubMovieService.readClubMovies(clubId);
+            ReadClubMoviesListResponse bookmarks = clubMovieService.readClubMovies(clubId, pageable);
 
             return new ReadClubDetailsResponse(
                     basicInfo.name(),

--- a/src/main/java/net/pointofviews/club/service/impl/MemberClubServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/MemberClubServiceImpl.java
@@ -1,0 +1,38 @@
+package net.pointofviews.club.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import net.pointofviews.club.dto.response.ReadClubMemberListResponse;
+import net.pointofviews.club.dto.response.ReadClubMemberResponse;
+import net.pointofviews.club.exception.ClubException;
+import net.pointofviews.club.repository.MemberClubRepository;
+import net.pointofviews.club.service.MemberClubService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberClubServiceImpl implements MemberClubService {
+
+    private final MemberClubRepository memberClubRepository;
+
+    @Override
+    public ReadClubMemberListResponse readMembersByClubId(UUID clubId) {
+        List<ReadClubMemberResponse> members = memberClubRepository.findMembersByClubId(clubId);
+        return new ReadClubMemberListResponse(members);
+    }
+
+    @Override
+    public boolean isMemberOfClub(UUID clubId, UUID memberId) {
+        return memberClubRepository.findByClubIdAndMemberId(clubId, memberId).isPresent();
+    }
+
+    @Override
+    public ReadClubMemberResponse readClubLeaderByClubId(UUID clubId) {
+        return memberClubRepository.findLeaderByClubId(clubId)
+                .orElseThrow(() -> ClubException.clubLeaderNotFound(clubId));
+    }
+}

--- a/src/main/java/net/pointofviews/movie/controller/MovieController.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieController.java
@@ -3,6 +3,7 @@ package net.pointofviews.movie.controller;
 import lombok.RequiredArgsConstructor;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.movie.dto.response.ReadDetailMovieResponse;
+import net.pointofviews.movie.dto.response.SearchMovieListResponse;
 import net.pointofviews.movie.dto.response.SearchMovieResponse;
 import net.pointofviews.movie.service.MovieContentService;
 import net.pointofviews.movie.service.MovieSearchService;
@@ -21,9 +22,9 @@ public class MovieController implements MovieSpecification {
 
     @Override
     @GetMapping("/search")
-    public ResponseEntity<BaseResponse<Slice<SearchMovieResponse>>> searchMovieList(@RequestParam String query,
-                                                                                    Pageable pageable) {
-        Slice<SearchMovieResponse> response = movieSearchService.searchMovies(query, pageable);
+    public ResponseEntity<BaseResponse<SearchMovieListResponse>> searchMovieList(@RequestParam String query,
+                                                                                 Pageable pageable) {
+        SearchMovieListResponse response = movieSearchService.searchMovies(query, pageable);
         return BaseResponse.ok("영화가 성공적으로 검색되었습니다.", response);
     }
 

--- a/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieSpecification.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.movie.dto.response.ReadDetailMovieResponse;
+import net.pointofviews.movie.dto.response.SearchMovieListResponse;
 import net.pointofviews.movie.dto.response.SearchMovieResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -37,8 +38,8 @@ public interface MovieSpecification {
                     )
             )
     })
-    ResponseEntity<BaseResponse<Slice<SearchMovieResponse>>> searchMovieList(@RequestParam String query,
-                                                                             Pageable pageable);
+    ResponseEntity<BaseResponse<SearchMovieListResponse>> searchMovieList(@RequestParam String query,
+                                                                          Pageable pageable);
 
     @Operation(summary = "영화 상세 조회", description = "영화 단건 상세 조회 API.")
     @ApiResponses({

--- a/src/main/java/net/pointofviews/movie/dto/response/SearchMovieListResponse.java
+++ b/src/main/java/net/pointofviews/movie/dto/response/SearchMovieListResponse.java
@@ -1,12 +1,13 @@
 package net.pointofviews.movie.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 @Schema(description = "Response containing a list of movies")
 public record SearchMovieListResponse(
         @Schema(description = "영화 리스트")
-        List<SearchMovieResponse> movies
+        Slice<SearchMovieResponse> movies
 ) {
 }

--- a/src/main/java/net/pointofviews/movie/service/MovieSearchService.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieSearchService.java
@@ -2,7 +2,6 @@ package net.pointofviews.movie.service;
 
 import net.pointofviews.movie.dto.response.*;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 public interface MovieSearchService {
     SearchMovieListResponse searchMovies(String query, Pageable pageable);

--- a/src/main/java/net/pointofviews/movie/service/MovieSearchService.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieSearchService.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface MovieSearchService {
-    Slice<SearchMovieResponse> searchMovies(String query, Pageable pageable);
+    SearchMovieListResponse searchMovies(String query, Pageable pageable);
 }

--- a/src/main/java/net/pointofviews/movie/service/impl/MovieSearchServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/impl/MovieSearchServiceImpl.java
@@ -1,6 +1,7 @@
 package net.pointofviews.movie.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import net.pointofviews.movie.dto.response.SearchMovieListResponse;
 import net.pointofviews.movie.dto.response.SearchMovieResponse;
 import net.pointofviews.movie.repository.MovieRepository;
 import net.pointofviews.movie.service.MovieSearchService;
@@ -17,16 +18,18 @@ public class MovieSearchServiceImpl implements MovieSearchService {
     private final MovieRepository movieRepository;
 
     @Override
-    public Slice<SearchMovieResponse> searchMovies(String query, Pageable pageable) {
+    public SearchMovieListResponse searchMovies(String query, Pageable pageable) {
 
-        return movieRepository.searchMoviesByTitleOrPeople(query, pageable)
-                .map(row -> new SearchMovieResponse(
-                        ((Number) row[0]).longValue(),  // id
-                        (String) row[1],               // title
-                        (String) row[2],               // poster
-                        (Date) row[3],               // released
-                        row[4] != null ? ((Number) row[4]).intValue() : 0,  // likeCount (null이면 0)
-                        row[5] != null ? ((Number) row[5]).intValue() : 0   // reviewCount (null이면 0)
-                ));
+        Slice<SearchMovieResponse> responses =  movieRepository.searchMoviesByTitleOrPeople(query, pageable)
+        .map(row -> new SearchMovieResponse(
+                ((Number) row[0]).longValue(),  // id
+                (String) row[1],               // title
+                (String) row[2],               // poster
+                (Date) row[3],               // released
+                row[4] != null ? ((Number) row[4]).intValue() : 0,  // likeCount (null이면 0)
+                row[5] != null ? ((Number) row[5]).intValue() : 0   // reviewCount (null이면 0)
+        ));
+
+        return new SearchMovieListResponse(responses);
     }
 }

--- a/src/main/resources/db/migration/V3.1__add_fulltext_ngram_club_index.sql
+++ b/src/main/resources/db/migration/V3.1__add_fulltext_ngram_club_index.sql
@@ -1,0 +1,10 @@
+-- 마이그레이션 버전: V3.1
+-- 설명: 클럽 이름(name)와 클럽 리더(nickname)에 대해 Ngram 기반 Full-Text 인덱스 추가
+-- 작성일: 2024-12-09
+
+-- ADD Full-Text + Ngram Index
+ALTER TABLE club
+    ADD FULLTEXT INDEX clubname_ngram_idx (name) WITH PARSER ngram;
+
+ALTER TABLE member
+    ADD FULLTEXT INDEX nickname_ngram_idx (nickname) WITH PARSER ngram;

--- a/src/test/java/net/pointofviews/club/service/ClubFavorGenreServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/ClubFavorGenreServiceImplTest.java
@@ -1,0 +1,95 @@
+package net.pointofviews.club.service;
+
+import net.pointofviews.club.repository.ClubFavorGenreRepository;
+import net.pointofviews.club.service.impl.ClubFavorGenreServiceImpl;
+import net.pointofviews.common.domain.CodeGroupEnum;
+import net.pointofviews.common.service.CommonCodeService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ClubFavorGenreServiceImplTest {
+
+    @InjectMocks
+    private ClubFavorGenreServiceImpl clubFavorGenreService;
+
+    @Mock
+    private ClubFavorGenreRepository clubFavorGenreRepository;
+
+    @Mock
+    private CommonCodeService commonCodeService;
+
+    @Nested
+    class ReadGenreNamesByClubId {
+
+        @Test
+        void 클럽_장르명_조회_성공() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            List<String> genreCodes = List.of("001", "002");
+            List<String> genreNames = List.of("Action", "Romance");
+
+            given(clubFavorGenreRepository.findGenresByClubId(clubId)).willReturn(genreCodes);
+            given(commonCodeService.convertCommonCodeToName("001", CodeGroupEnum.MOVIE_GENRE)).willReturn("Action");
+            given(commonCodeService.convertCommonCodeToName("002", CodeGroupEnum.MOVIE_GENRE)).willReturn("Romance");
+
+            // when
+            List<String> result = clubFavorGenreService.readGenreNamesByClubId(clubId);
+
+            // then
+            assertThat(result).containsExactly("Action", "Romance");
+            verify(clubFavorGenreRepository).findGenresByClubId(clubId);
+            verify(commonCodeService).convertCommonCodeToName("001", CodeGroupEnum.MOVIE_GENRE);
+            verify(commonCodeService).convertCommonCodeToName("002", CodeGroupEnum.MOVIE_GENRE);
+        }
+
+        @Test
+        void 클럽_장르명_조회_성공_빈_리스트() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            List<String> genreCodes = List.of();
+
+            given(clubFavorGenreRepository.findGenresByClubId(clubId)).willReturn(genreCodes);
+
+            // when
+            List<String> result = clubFavorGenreService.readGenreNamesByClubId(clubId);
+
+            // then
+            assertThat(result).isEmpty();
+            verify(clubFavorGenreRepository).findGenresByClubId(clubId);
+        }
+
+        @Test
+        void 장르_코드에_해당하는_이름_찾을_수_없음() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            List<String> genreCodes = List.of("001", "999"); // 999는 없는 코드
+
+            given(clubFavorGenreRepository.findGenresByClubId(clubId)).willReturn(genreCodes);
+            given(commonCodeService.convertCommonCodeToName("001", CodeGroupEnum.MOVIE_GENRE)).willReturn("Action");
+            given(commonCodeService.convertCommonCodeToName("999", CodeGroupEnum.MOVIE_GENRE))
+                    .willThrow(new RuntimeException("코드 999에 해당하는 장르명을 찾을 수 없습니다."));
+
+            // when & then
+            assertThatThrownBy(() -> clubFavorGenreService.readGenreNamesByClubId(clubId))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("코드 999에 해당하는 장르명을 찾을 수 없습니다.");
+
+            verify(clubFavorGenreRepository).findGenresByClubId(clubId);
+            verify(commonCodeService).convertCommonCodeToName("001", CodeGroupEnum.MOVIE_GENRE);
+            verify(commonCodeService).convertCommonCodeToName("999", CodeGroupEnum.MOVIE_GENRE);
+        }
+    }
+}

--- a/src/test/java/net/pointofviews/club/service/ClubMovieServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/ClubMovieServiceImplTest.java
@@ -1,0 +1,81 @@
+package net.pointofviews.club.service;
+
+import net.pointofviews.club.dto.response.ReadClubMovieResponse;
+import net.pointofviews.club.dto.response.ReadClubMoviesListResponse;
+import net.pointofviews.club.repository.ClubMoviesRepository;
+import net.pointofviews.club.service.impl.ClubMovieServiceImpl;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ClubMovieServiceImplTest {
+
+    @InjectMocks
+    private ClubMovieServiceImpl clubMovieService;
+
+    @Mock
+    private ClubMoviesRepository clubMoviesRepository;
+
+    @Nested
+    class ReadClubMovies {
+
+        @Test
+        void 클럽_영화_조회_성공() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            PageRequest pageable = PageRequest.of(0, 10);
+
+            List<ReadClubMovieResponse> movieList = List.of(
+                    new ReadClubMovieResponse("Inception", "https://example.com/poster1.jpg", LocalDate.of(2010, 7, 16), 156L, 15L),
+                    new ReadClubMovieResponse("Interstellar", "https://example.com/poster2.jpg", LocalDate.of(2014, 11, 7), 200L, 25L)
+            );
+            Slice<ReadClubMovieResponse> movies = new SliceImpl<>(movieList, pageable, true);
+
+            given(clubMoviesRepository.findMovieDetailsByClubId(clubId, pageable)).willReturn(movies);
+
+            // when
+            ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, pageable);
+
+            // then
+            assertThat(response.clubMovies().getContent()).hasSize(2);
+            assertThat(response.clubMovies().getContent().get(0).title()).isEqualTo("Inception");
+            assertThat(response.clubMovies().getContent().get(1).title()).isEqualTo("Interstellar");
+
+            verify(clubMoviesRepository).findMovieDetailsByClubId(clubId, pageable);
+        }
+
+        @Test
+        void 클럽_영화_조회_결과가_없는_경우() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            PageRequest pageable = PageRequest.of(0, 10);
+
+            Slice<ReadClubMovieResponse> emptyMovies = new SliceImpl<>(List.of(), pageable, false);
+
+            given(clubMoviesRepository.findMovieDetailsByClubId(clubId, pageable)).willReturn(emptyMovies);
+
+            // when
+            ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, pageable);
+
+            // then
+            assertThat(response.clubMovies().getContent()).isEmpty();
+
+            verify(clubMoviesRepository).findMovieDetailsByClubId(clubId, pageable);
+        }
+    }
+}

--- a/src/test/java/net/pointofviews/club/service/ClubServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/ClubServiceImplTest.java
@@ -13,6 +13,7 @@ import net.pointofviews.club.exception.ClubException;
 import net.pointofviews.club.repository.ClubFavorGenreRepository;
 import net.pointofviews.club.repository.ClubRepository;
 import net.pointofviews.club.repository.MemberClubRepository;
+import net.pointofviews.club.service.impl.ClubServiceImpl;
 import net.pointofviews.common.exception.CommonCodeException;
 import net.pointofviews.common.exception.S3Exception;
 import net.pointofviews.common.service.CommonCodeService;

--- a/src/test/java/net/pointofviews/club/service/MemberClubServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/MemberClubServiceImplTest.java
@@ -1,0 +1,131 @@
+package net.pointofviews.club.service;
+
+import net.pointofviews.club.domain.MemberClub;
+import net.pointofviews.club.dto.response.ReadClubMemberListResponse;
+import net.pointofviews.club.dto.response.ReadClubMemberResponse;
+import net.pointofviews.club.exception.ClubException;
+import net.pointofviews.club.repository.MemberClubRepository;
+import net.pointofviews.club.service.impl.MemberClubServiceImpl;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberClubServiceImplTest {
+
+    @InjectMocks
+    private MemberClubServiceImpl memberClubService;
+
+    @Mock
+    private MemberClubRepository memberClubRepository;
+
+    @Nested
+    class ReadMembersByClubId {
+
+        @Test
+        void 클럽_멤버_조회_성공() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            List<ReadClubMemberResponse> members = List.of(
+                    new ReadClubMemberResponse("nickname1", "https://example.com/image.jpg", false),
+                    new ReadClubMemberResponse("nickname2", "https://example.com/image2.jpg", true)
+            );
+
+            given(memberClubRepository.findMembersByClubId(clubId)).willReturn(members);
+
+            // when
+            ReadClubMemberListResponse response = memberClubService.readMembersByClubId(clubId);
+
+            // then
+            assertThat(response.memberList()).hasSize(2);
+            assertThat(response.memberList().get(0).nickname()).isEqualTo("nickname1");
+            assertThat(response.memberList().get(1).isLeader()).isTrue();
+            verify(memberClubRepository).findMembersByClubId(clubId);
+        }
+    }
+
+    @Nested
+    class IsMemberOfClub {
+
+        @Test
+        void 클럽_멤버_여부_확인_성공() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            UUID memberId = UUID.randomUUID();
+
+            MemberClub memberClub = mock(MemberClub.class);
+            given(memberClubRepository.findByClubIdAndMemberId(clubId, memberId)).willReturn(Optional.of(memberClub));
+
+            // when
+            boolean isMember = memberClubService.isMemberOfClub(clubId, memberId);
+
+            // then
+            assertThat(isMember).isTrue();
+            verify(memberClubRepository).findByClubIdAndMemberId(clubId, memberId);
+        }
+
+
+        @Test
+        void 클럽_멤버_여부_확인_실패() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            UUID memberId = UUID.randomUUID();
+
+            given(memberClubRepository.findByClubIdAndMemberId(clubId, memberId)).willReturn(Optional.empty());
+
+            // when
+            boolean isMember = memberClubService.isMemberOfClub(clubId, memberId);
+
+            // then
+            assertThat(isMember).isFalse();
+            verify(memberClubRepository).findByClubIdAndMemberId(clubId, memberId);
+        }
+    }
+
+    @Nested
+    class ReadClubLeaderByClubId {
+
+        @Test
+        void 클럽_리더_조회_성공() {
+            // given
+            UUID clubId = UUID.randomUUID();
+            ReadClubMemberResponse leader = new ReadClubMemberResponse("leaderNickname", "https://example.com/image.jpg", true);
+
+            given(memberClubRepository.findLeaderByClubId(clubId)).willReturn(Optional.of(leader));
+
+            // when
+            ReadClubMemberResponse response = memberClubService.readClubLeaderByClubId(clubId);
+
+            // then
+            assertThat(response.nickname()).isEqualTo("leaderNickname");
+            assertThat(response.isLeader()).isTrue();
+            verify(memberClubRepository).findLeaderByClubId(clubId);
+        }
+
+        @Test
+        void 클럽_리더_조회_실패() {
+            // given
+            UUID clubId = UUID.randomUUID();
+
+            given(memberClubRepository.findLeaderByClubId(clubId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberClubService.readClubLeaderByClubId(clubId))
+                    .isInstanceOf(ClubException.class)
+                    .hasMessageContaining(String.format("클럽(ID: %s)의 리더를 찾을 수 없습니다.", clubId));
+        }
+    }
+}


### PR DESCRIPTION
## PR 설명
- 클럽 상세 조회 구현
- 클럽 별 영화 북마크 조회 구현
- 클럽 검색 API 추가 및 응답 값 추가
- 클럽 전체 조회, 내 클럽 조회, 상세 조회, 클럽 별 영화 북마크 조회, 클럽 멤버 조회 테스트 구현
- 클럽 (클럽이름, 리더작성자) 검색 기능 구현 
- flyway v3.1 club, member INDEX 추가

## 📸 스크린샷
- 클럽 별 상세 조회
<img width="953" alt="Screenshot 2024-12-09 at 17 36 28" src="https://github.com/user-attachments/assets/9df27e41-6187-4bdb-844c-ad428fcc83a5">
<img width="785" alt="Screenshot 2024-12-09 at 17 36 39" src="https://github.com/user-attachments/assets/61199e0d-4045-466b-aa6c-f03e34e73e2d">

- 클럽 영화 북마크 조회
<img width="1026" alt="Screenshot 2024-12-09 at 18 11 41" src="https://github.com/user-attachments/assets/a36d961e-9e68-4aa7-8403-33daf225157a">

- 클럽 검색 기능 
<img width="1178" alt="Screenshot 2024-12-09 at 23 32 29" src="https://github.com/user-attachments/assets/97a2c48a-588f-4fcd-95d6-2b76e498aa13">


- 테스트
<img width="730" alt="Screenshot 2024-12-09 at 19 28 18" src="https://github.com/user-attachments/assets/bf11452c-da35-4839-8d55-c1684d7f126e">
<img width="720" alt="Screenshot 2024-12-09 at 19 40 01" src="https://github.com/user-attachments/assets/6bfe3be5-2058-4bbf-a5aa-97fe3fa82f36">
<img width="724" alt="Screenshot 2024-12-09 at 19 44 13" src="https://github.com/user-attachments/assets/0a7bba92-f42f-4d95-80e4-5142e8221505">
<img width="728" alt="Screenshot 2024-12-09 at 19 47 36" src="https://github.com/user-attachments/assets/f2164943-a452-4c7f-bba7-abfa9c013744">


## 고민과 해결과정
- 클럽 상세 조회를 진행할때 불러와야할 데이터가 많아서 고민하다가 서비스 별로 나눠서 구현을 진행했습니다.
- 이후 관련 부분 리팩토링 진행 고민중입니다.
- 영화, 클럽 검색 부분 테스트 추가 예정