### PR TITLE
feat: 관리자 시사회 삭제 구현 및 단위 테스트 작성

### DIFF
--- a/src/main/java/net/pointofviews/common/service/S3Service.java
+++ b/src/main/java/net/pointofviews/common/service/S3Service.java
@@ -1,7 +1,5 @@
 package net.pointofviews.common.service;
 
-import java.util.List;
-
 import org.springframework.web.multipart.MultipartFile;
 
 public interface S3Service {

--- a/src/main/java/net/pointofviews/premiere/controller/PremiereAdminController.java
+++ b/src/main/java/net/pointofviews/premiere/controller/PremiereAdminController.java
@@ -47,10 +47,11 @@ public class PremiereAdminController implements PremiereAdminSpecification {
     @DeleteMapping("/{premiereId}")
     public ResponseEntity<BaseResponse<Void>> deletePremiere(
             @AuthenticationPrincipal(expression = "member") Member loginMember,
-            @PathVariable Long premiereId,
-            @RequestBody @Valid PremiereRequest request
+            @PathVariable Long premiereId
     ) {
-        return null;
+        premiereAdminService.deletePremiere(loginMember, premiereId);
+
+        return BaseResponse.ok("시사회가 성공적으로 삭제되었습니다.");
     }
 
     @Override

--- a/src/main/java/net/pointofviews/premiere/controller/specification/PremiereAdminSpecification.java
+++ b/src/main/java/net/pointofviews/premiere/controller/specification/PremiereAdminSpecification.java
@@ -71,12 +71,19 @@ public interface PremiereAdminSpecification {
                               "message": "시사회가 성공적으로 삭제되었습니다."
                             }
                             """)
+            )),
+            @ApiResponse(responseCode = "404", description = "시사회 상세 조회 실패 - 존재하지 않는 시사회", content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                              "message": "시사회(Id: 123)가 존재하지 않습니다."
+                            }
+                            """)
             ))
     })
     ResponseEntity<BaseResponse<Void>> deletePremiere(
             @AuthenticationPrincipal(expression = "member") Member loginMember,
-            @Parameter(description = "삭제할 시사회 ID", example = "123") Long premiereId,
-            @RequestBody @Valid PremiereRequest request
+            @Parameter(description = "삭제할 시사회 ID", example = "123") Long premiereId
     );
 
     @Operation(
@@ -94,15 +101,14 @@ public interface PremiereAdminSpecification {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "시사회 상세 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "시사회 상세 조회 실패 - 존재하지 않는 시사회",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "message": "존재하지 않는 시사회입니다."
-                                    }
-                                    """)
-                    ))
+            @ApiResponse(responseCode = "404", description = "시사회 상세 조회 실패 - 존재하지 않는 시사회", content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                              "message": "시사회(Id: 123)가 존재하지 않습니다."
+                            }
+                            """)
+            ))
 
     })
     ResponseEntity<BaseResponse<ReadDetailPremiereResponse>> readPremiereDetails(

--- a/src/main/java/net/pointofviews/premiere/service/imple/PremiereAdminServiceImpl.java
+++ b/src/main/java/net/pointofviews/premiere/service/imple/PremiereAdminServiceImpl.java
@@ -1,6 +1,7 @@
 package net.pointofviews.premiere.service.imple;
 
 import lombok.RequiredArgsConstructor;
+import net.pointofviews.common.service.S3Service;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.repository.MemberRepository;
 import net.pointofviews.premiere.domain.Premiere;
@@ -21,6 +22,7 @@ public class PremiereAdminServiceImpl implements PremiereAdminService {
 
     private final PremiereRepository premiereRepository;
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
 
     @Override
     public void savePremiere(Member loginMember, PremiereRequest premiere) {
@@ -41,7 +43,21 @@ public class PremiereAdminServiceImpl implements PremiereAdminService {
     }
 
     @Override
+    @Transactional
     public void deletePremiere(Member loginMember, Long premiereId) {
+
+        if (memberRepository.findById(loginMember.getId()).isEmpty()) {
+            throw adminNotFound(loginMember.getId());
+        }
+
+        Premiere premiere = premiereRepository.findById(premiereId)
+                .orElseThrow(() -> premiereNotFound(premiereId));
+
+        if (premiere.getEventImage() != null) {
+            s3Service.deleteImage(premiere.getEventImage());
+        }
+
+        premiereRepository.delete(premiere);
     }
 
     @Override

--- a/src/test/java/net/pointofviews/premiere/service/PremiereAdminServiceTest.java
+++ b/src/test/java/net/pointofviews/premiere/service/PremiereAdminServiceTest.java
@@ -1,5 +1,6 @@
 package net.pointofviews.premiere.service;
 
+import net.pointofviews.common.service.S3Service;
 import net.pointofviews.fixture.PremiereFixture;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.exception.MemberException;
@@ -39,6 +40,9 @@ class PremiereAdminServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private S3Service s3Service;
 
     @Nested
     class UpdatePremiere {
@@ -120,6 +124,95 @@ class PremiereAdminServiceTest {
                 assertSoftly(softly -> {
                    softly.assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
                    softly.assertThat(exception.getMessage()).isEqualTo(String.format("시사회(Id: %d)가 존재하지 않습니다.", -1L));
+                });
+            }
+        }
+    }
+
+    @Nested
+    class DeletePremiere {
+
+        @Nested
+        class Success {
+
+            @Test
+            void 이미지를_포함한_시사회_정보_삭제() {
+                // given -- 테스트의 상태 설정
+                Member admin = mock(Member.class);
+                Premiere premiere = PremiereFixture.createPremiere();
+
+                given(memberRepository.findById(any())).willReturn(Optional.of(admin));
+                given(premiereRepository.findById(any())).willReturn(Optional.of(premiere));
+
+                // when -- 테스트하고자 하는 행동
+                premiereAdminService.deletePremiere(admin, 1L);
+
+                // then -- 예상되는 변화 및 결과
+                verify(s3Service, times(1)).deleteImage(any());
+                verify(premiereRepository, times(1)).delete(any());
+            }
+
+            @Test
+            void 이미지가_null_인_시사회_정보_삭제() {
+                // given -- 테스트의 상태 설정
+                Member admin = mock(Member.class);
+                Premiere premiere = mock(Premiere.class);
+
+                given(memberRepository.findById(any())).willReturn(Optional.of(admin));
+                given(premiereRepository.findById(any())).willReturn(Optional.of(premiere));
+
+                // when -- 테스트하고자 하는 행동
+                premiereAdminService.deletePremiere(admin, 1L);
+
+                // then -- 예상되는 변화 및 결과
+                verify(s3Service, times(0)).deleteImage(any());
+                verify(premiereRepository, times(1)).delete(any());
+            }
+        }
+
+        @Nested
+        class Failure {
+
+            @Test
+            void 존재하지_않는_관리자_MemberException_memberNotFound_예외발생() {
+                // given -- 테스트의 상태 설정
+                Member admin = mock(Member.class);
+                UUID adminId = UUID.randomUUID();
+
+                given(admin.getId()).willReturn(adminId);
+                given(memberRepository.findById(any())).willReturn(Optional.empty());
+
+                // when -- 테스트하고자 하는 행동
+                MemberException exception = assertThrows(MemberException.class, () ->
+                        premiereAdminService.deletePremiere(admin, 1L)
+                );
+
+                // then -- 예상되는 변화 및 결과
+                assertSoftly(softly -> {
+                    softly.assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+                    softly.assertThat(exception.getMessage()).isEqualTo(String.format("관리자(Id: %s)가 존재하지 않습니다.", adminId));
+                    verify(premiereRepository, times(0)).findById(any());
+                });
+            }
+
+            @Test
+            void 존재하지_않는_시사회_PremiereException_premiereNotFound_예외발생() {
+                // given -- 테스트의 상태 설정
+                Member admin = mock(Member.class);
+                Premiere premiere = mock(Premiere.class);
+
+                given(memberRepository.findById(any())).willReturn(Optional.of(admin));
+                given(premiereRepository.findById(any())).willReturn(Optional.empty());
+
+                // when -- 테스트하고자 하는 행동
+                PremiereException exception = assertThrows(PremiereException.class, () ->
+                        premiereAdminService.deletePremiere(admin, -1L)
+                );
+
+                // then -- 예상되는 변화 및 결과
+                assertSoftly(softly -> {
+                    softly.assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+                    softly.assertThat(exception.getMessage()).isEqualTo(String.format("시사회(Id: %d)가 존재하지 않습니다.", -1L));
                 });
             }
         }


### PR DESCRIPTION
## PR 설명
- 관리자 시사회 삭제 구현
- 관리자 시사회 삭제 테스트 작성

## 📸 스크린샷

> 시사회 삭제

![image](https://github.com/user-attachments/assets/2a5624af-80ba-4f65-9581-3ffc66bb92da)

> 해당 시사회 이미지 삭제

![image](https://github.com/user-attachments/assets/d2828068-fabb-4933-b9ca-2198dff8b663)

> 관리자 시사회 삭제 테스트

![image](https://github.com/user-attachments/assets/6e9a9621-e5b7-4f47-bc6c-f2e7b8aeaa05)


## 고민과 해결과정
