### PR TITLE
refactor: 리뷰 조회 시 응답DTO에 movieId 추가 & Null 처리

### DIFF
--- a/src/main/java/net/pointofviews/club/repository/MemberClubRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/MemberClubRepository.java
@@ -29,6 +29,7 @@ public interface MemberClubRepository extends JpaRepository<MemberClub, Long> {
     @Query(value = """
             SELECT new net.pointofviews.review.dto.response.ReadReviewResponse(
                     r.id,
+                    mv.id,
                     mv.title,
                     r.title,
                     r.contents,

--- a/src/main/java/net/pointofviews/review/dto/response/ReadReviewResponse.java
+++ b/src/main/java/net/pointofviews/review/dto/response/ReadReviewResponse.java
@@ -1,14 +1,17 @@
 package net.pointofviews.review.dto.response;
 
-import java.time.LocalDateTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
 
 @Schema(description = "리뷰 DTO")
 public record ReadReviewResponse(
 
 	@Schema(description = "리뷰 ID", example = "1")
 	Long reviewId,
+
+	@Schema(description = "영화 ID", example = "1")
+	Long movieId,
 
 	@Schema(description = "영화 제목", example = "Inception")
 	String movieTitle,

--- a/src/main/java/net/pointofviews/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/net/pointofviews/review/repository/ReviewLikeRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.repository.query.Param;
 
 import net.pointofviews.review.domain.ReviewLike;
 
+import java.util.Optional;
+
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
 	@Query(value = """
@@ -13,5 +15,5 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 		  FROM ReviewLike rl
 		 WHERE rl.review.id = :reviewId
 	""")
-	boolean getIsLikedByReviewId(@Param("reviewId") Long reviewId);
+	Optional<Boolean> getIsLikedByReviewId(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/net/pointofviews/review/repository/ReviewRepository.java
+++ b/src/main/java/net/pointofviews/review/repository/ReviewRepository.java
@@ -16,6 +16,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query(value = """
             	SELECT new net.pointofviews.review.dto.response.ReadReviewResponse(
             			r.id,
+                        mv.id,
             			mv.title,
             			r.title,
             			r.contents,
@@ -38,6 +39,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query(value = """
             	SELECT new net.pointofviews.review.dto.response.ReadReviewResponse(
             			r.id,
+                        mv.id,
             			mv.title,
             			r.title,
             			r.contents,

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
@@ -195,7 +195,7 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
                 .orElseThrow(() -> reviewNotFound(reviewId));
 
         Long likeAmount = reviewLikeCountRepository.getReviewLikeCountByReviewId(reviewId);
-        boolean isLiked = reviewLikeRepository.getIsLikedByReviewId(reviewId);
+        boolean isLiked = reviewLikeRepository.getIsLikedByReviewId(reviewId).orElse(false);
         List<String> keywords = reviewKeywordLinkRepository.findKeywordsByReviewId(reviewId);
 
         ReadReviewDetailResponse response = new ReadReviewDetailResponse(

--- a/src/test/java/net/pointofviews/fixture/ReviewFixture.java
+++ b/src/test/java/net/pointofviews/fixture/ReviewFixture.java
@@ -14,6 +14,7 @@ public class ReviewFixture {
 
         return new ReadReviewResponse(
                 (long) RANDOM.nextInt(100),
+                (long) RANDOM.nextInt(100),
                 "영화 제목 " + RANDOM.nextInt(10),
                 "리뷰 제목 " + UUID.randomUUID(),
                 "리뷰 내용 " + UUID.randomUUID(),

--- a/src/test/java/net/pointofviews/review/service/ReviewMemberServiceTest.java
+++ b/src/test/java/net/pointofviews/review/service/ReviewMemberServiceTest.java
@@ -545,7 +545,7 @@ class ReviewMemberServiceTest {
                 given(review.getMember()).willReturn(member);
 
                 given(reviewRepository.findReviewDetailById(any())).willReturn(Optional.of(review));
-                given(reviewLikeRepository.getIsLikedByReviewId(any())).willReturn(true);
+                given(reviewLikeRepository.getIsLikedByReviewId(any())).willReturn(Optional.of(true));
                 given(reviewLikeCountRepository.getReviewLikeCountByReviewId(any())).willReturn(10L);
                 given(reviewKeywordLinkRepository.findKeywordsByReviewId(any())).willReturn(List.of("흥미진진", "몰입감"));
 


### PR DESCRIPTION
## PR 설명
- 리뷰 조회 관련 모든 응답 DTO에 movieId 추가
- Optional 로 Boolean 을 감싸서 null 반환 시 false 반환되도록 수정

## 📸 스크린샷


## 고민과 해결과정
