### PR TITLE
refactor: redis에 선호장르 저장관련 오류 수정

### DIFF
--- a/src/main/java/net/pointofviews/member/service/MemberRedisService.java
+++ b/src/main/java/net/pointofviews/member/service/MemberRedisService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @Slf4j

--- a/src/main/java/net/pointofviews/member/service/MemberRedisService.java
+++ b/src/main/java/net/pointofviews/member/service/MemberRedisService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -15,6 +17,7 @@ public class MemberRedisService {
     private final RedisTemplate<String, String> redisTemplate;
     private static final String GENRE_PREFERENCES_KEY = "genre:preferences:";
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void saveGenresToRedis(UUID memberId, List<String> genreCodes) {
         genreCodes.forEach(genreCode -> {
             String key = GENRE_PREFERENCES_KEY + genreCode;
@@ -22,6 +25,7 @@ public class MemberRedisService {
         });
     }
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void updateGenresInRedis(UUID memberId, List<String> existingGenreCodes, List<String> newGenreCodes) {
         // 기존 장르 삭제
         existingGenreCodes.forEach(genreCode -> {

--- a/src/main/java/net/pointofviews/member/service/MemberRedisService.java
+++ b/src/main/java/net/pointofviews/member/service/MemberRedisService.java
@@ -1,0 +1,39 @@
+package net.pointofviews.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberRedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String GENRE_PREFERENCES_KEY = "genre:preferences:";
+
+    public void saveGenresToRedis(UUID memberId, List<String> genreCodes) {
+        genreCodes.forEach(genreCode -> {
+            String key = GENRE_PREFERENCES_KEY + genreCode;
+            redisTemplate.opsForSet().add(key, memberId.toString());
+        });
+    }
+
+    public void updateGenresInRedis(UUID memberId, List<String> existingGenreCodes, List<String> newGenreCodes) {
+        // 기존 장르 삭제
+        existingGenreCodes.forEach(genreCode -> {
+            String key = GENRE_PREFERENCES_KEY + genreCode;
+            redisTemplate.opsForSet().remove(key, memberId.toString());
+        });
+
+        // 새로운 장르 추가
+        newGenreCodes.forEach(genreCode -> {
+            String key = GENRE_PREFERENCES_KEY + genreCode;
+            redisTemplate.opsForSet().add(key, memberId.toString());
+        });
+    }
+}

--- a/src/main/java/net/pointofviews/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/member/service/impl/MemberServiceImpl.java
@@ -8,13 +8,11 @@ import net.pointofviews.common.service.CommonCodeService;
 import net.pointofviews.member.domain.*;
 import net.pointofviews.member.repository.MemberFavorGenreRepository;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import net.pointofviews.member.repository.MemberFcmTokenRepository;
+import net.pointofviews.member.service.MemberRedisService;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +47,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberFavorGenreRepository memberFavorGenreRepository;
     private final MemberFcmTokenRepository memberFcmTokenRepository;
     private final CommonCodeService commonCodeService;
+    private final MemberRedisService memberRedisService;
     private final S3Service s3Service;
 
     @Override
@@ -82,30 +81,22 @@ public class MemberServiceImpl implements MemberService {
 
         // 관심 장르 저장
         if (!request.favorGenres().isEmpty()) {
-            request.favorGenres().forEach(genreName -> {
-                String genreCode = commonCodeService.convertNameToCommonCode(
-                        genreName,
-                        CodeGroupEnum.MOVIE_GENRE
-                );
+            List<String> genreCodes = request.favorGenres().stream()
+                    .map(genreName -> commonCodeService.convertNameToCommonCode(
+                            genreName,
+                            CodeGroupEnum.MOVIE_GENRE
+                    ))
+                    .toList();
 
+            genreCodes.forEach(genreCode -> {
                 MemberFavorGenre favorGenre = MemberFavorGenre.builder()
                         .member(savedMember)
                         .genreCode(genreCode)
                         .build();
                 memberFavorGenreRepository.save(favorGenre);
             });
-        }
 
-        // Redis에 선호 장르 저장
-        if (!request.favorGenres().isEmpty()) {
-            request.favorGenres().forEach(genreName -> {
-                String genreCode = commonCodeService.convertNameToCommonCode(
-                        genreName,
-                        CodeGroupEnum.MOVIE_GENRE
-                );
-                String key = GENRE_PREFERENCES_KEY + genreCode;
-                redisTemplate.opsForSet().add(key, savedMember.getId().toString());
-            });
+            memberRedisService.saveGenresToRedis(savedMember.getId(), genreCodes);
         }
 
         return new CreateMemberResponse(
@@ -194,15 +185,7 @@ public class MemberServiceImpl implements MemberService {
         });
 
         // Redis 업데이트
-        existingGenreCodes.forEach(genreCode -> {
-            String key = GENRE_PREFERENCES_KEY + genreCode;
-            redisTemplate.opsForSet().remove(key, loginMember.getId().toString());
-        });
-
-        requestGenreCodes.forEach(genreCode -> {
-            String key = GENRE_PREFERENCES_KEY + genreCode;
-            redisTemplate.opsForSet().add(key, loginMember.getId().toString());
-        });
+        memberRedisService.updateGenresInRedis(member.getId(), existingGenreCodes, requestGenreCodes);
 
         return new PutMemberGenreListResponse(request.genres());
     }

--- a/src/main/java/net/pointofviews/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/member/service/impl/MemberServiceImpl.java
@@ -40,9 +40,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
-    private static final String GENRE_PREFERENCES_KEY = "genre:preferences:";
-    private final RedisTemplate<String, Object> redisTemplate;
-
     private final MemberRepository memberRepository;
     private final MemberFavorGenreRepository memberFavorGenreRepository;
     private final MemberFcmTokenRepository memberFcmTokenRepository;

--- a/src/main/java/net/pointofviews/notice/exception/NoticeException.java
+++ b/src/main/java/net/pointofviews/notice/exception/NoticeException.java
@@ -1,7 +1,10 @@
 package net.pointofviews.notice.exception;
 
 import net.pointofviews.common.exception.BusinessException;
+import net.pointofviews.member.exception.MemberException;
 import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
 
 public class NoticeException extends BusinessException {
 
@@ -34,8 +37,8 @@ public class NoticeException extends BusinessException {
     }
 
     public static class NoTargetMembersFoundException extends NoticeException {
-        public NoTargetMembersFoundException() {
-            super(HttpStatus.NOT_FOUND, "알림을 받을 대상자가 없습니다.");
+        public NoTargetMembersFoundException(String genre, String code) {
+            super(HttpStatus.NOT_FOUND, String.format("영화장르(장르명: %s, 장르코드: %s)에 대한 알림을 받을 대상자가 없습니다.", genre, code));
         }
     }
 

--- a/src/main/java/net/pointofviews/notice/exception/NoticeException.java
+++ b/src/main/java/net/pointofviews/notice/exception/NoticeException.java
@@ -1,10 +1,7 @@
 package net.pointofviews.notice.exception;
 
 import net.pointofviews.common.exception.BusinessException;
-import net.pointofviews.member.exception.MemberException;
 import org.springframework.http.HttpStatus;
-
-import java.util.UUID;
 
 public class NoticeException extends BusinessException {
 

--- a/src/main/java/net/pointofviews/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/net/pointofviews/notice/service/NoticeServiceImpl.java
@@ -88,7 +88,10 @@ public class NoticeServiceImpl implements NoticeService {
         Set<UUID> targetMembers = getTargetMembers(genreKey);
 
         if (targetMembers.isEmpty()) {
-            throw new NoticeException.NoTargetMembersFoundException();
+            String message = String.format("영화장르(장르명: %s, 장르코드: %s)에 대한 알림을 받을 대상자가 없습니다.",
+                    genreName, genreCode);
+            log.info(message);
+            return;
         }
 
         // 배치 처리

--- a/src/main/java/net/pointofviews/review/service/ReviewNotificationService.java
+++ b/src/main/java/net/pointofviews/review/service/ReviewNotificationService.java
@@ -1,0 +1,53 @@
+package net.pointofviews.review.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.pointofviews.common.domain.CodeGroupEnum;
+import net.pointofviews.common.service.CommonCodeService;
+import net.pointofviews.movie.domain.Movie;
+import net.pointofviews.movie.domain.MovieGenre;
+import net.pointofviews.notice.dto.request.SendNoticeRequest;
+import net.pointofviews.notice.service.NoticeService;
+import net.pointofviews.review.domain.Review;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReviewNotificationService {
+
+    private final NoticeService noticeService;
+    private final CommonCodeService commonCodeService;
+    private static final Long REVIEW_NOTICE_TEMPLATE_ID = 1L;  // 알림 템플릿 ID
+
+    @Transactional
+    public void sendReviewNotifications(Review review) {
+        Movie movie = review.getMovie();
+        for (MovieGenre movieGenre : movie.getGenres()) {
+            String genreName = commonCodeService.convertCommonCodeToName(
+                    movieGenre.getGenreCode(),
+                    CodeGroupEnum.MOVIE_GENRE
+            );
+
+            String noticeContent = String.format("%s 장르의 '%s'에 새로운 리뷰가 작성되었습니다.",
+                    genreName, movie.getTitle());
+
+            Map<String, String> templateVariables = new HashMap<>();
+            templateVariables.put("genre", genreName);
+            templateVariables.put("movieTitle", movie.getTitle());
+            templateVariables.put("review_id", String.valueOf(review.getId()));
+            templateVariables.put("notice_content", noticeContent);
+
+            SendNoticeRequest noticeRequest = new SendNoticeRequest(
+                    REVIEW_NOTICE_TEMPLATE_ID,
+                    templateVariables
+            );
+
+            noticeService.sendNotice(noticeRequest);
+        }
+    }
+}

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
@@ -9,7 +9,6 @@ import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.repository.MemberRepository;
 import net.pointofviews.movie.domain.Movie;
 import net.pointofviews.movie.repository.MovieRepository;
-import net.pointofviews.notice.service.NoticeService;
 import net.pointofviews.review.domain.Review;
 import net.pointofviews.review.domain.ReviewKeywordLink;
 import net.pointofviews.review.dto.request.CreateReviewRequest;

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
@@ -8,9 +8,7 @@ import net.pointofviews.common.service.S3Service;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.repository.MemberRepository;
 import net.pointofviews.movie.domain.Movie;
-import net.pointofviews.movie.domain.MovieGenre;
 import net.pointofviews.movie.repository.MovieRepository;
-import net.pointofviews.notice.dto.request.SendNoticeRequest;
 import net.pointofviews.notice.service.NoticeService;
 import net.pointofviews.review.domain.Review;
 import net.pointofviews.review.domain.ReviewKeywordLink;
@@ -23,6 +21,7 @@ import net.pointofviews.review.repository.ReviewLikeCountRepository;
 import net.pointofviews.review.repository.ReviewLikeRepository;
 import net.pointofviews.review.repository.ReviewRepository;
 import net.pointofviews.review.service.ReviewMemberService;
+import net.pointofviews.review.service.ReviewNotificationService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -51,10 +50,8 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
     private final ReviewLikeCountRepository reviewLikeCountRepository;
     private final ReviewKeywordLinkRepository reviewKeywordLinkRepository;
     private final CommonCodeService commonCodeService;
+    private final ReviewNotificationService reviewNotificationService;
     private final S3Service s3Service;
-    private final NoticeService noticeService;
-    private static final Long REVIEW_NOTICE_TEMPLATE_ID = 1L;  // 알림 템플릿 ID
-
 
     @Override
     @Transactional
@@ -94,34 +91,7 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
         }
 
         // 알림 발송
-        try {
-            movie = review.getMovie();
-
-            // 영화의 모든 장르에 대해 알림을 발송
-            for (MovieGenre movieGenre : movie.getGenres()) {
-                String genreName = commonCodeService.convertCommonCodeToName(
-                        movieGenre.getGenreCode(),
-                        CodeGroupEnum.MOVIE_GENRE
-                );
-
-                String noticeContent = String.format("%s 장르의 '%s'에 새로운 리뷰가 작성되었습니다.", genreName, movie.getTitle());
-
-                Map<String, String> templateVariables = new HashMap<>();
-                templateVariables.put("genre", genreName);
-                templateVariables.put("movieTitle", movie.getTitle());
-                templateVariables.put("review_id", String.valueOf(review.getId()));
-                templateVariables.put("notice_content", noticeContent);
-
-                SendNoticeRequest noticeRequest = new SendNoticeRequest(
-                        REVIEW_NOTICE_TEMPLATE_ID,
-                        templateVariables
-                );
-
-                noticeService.sendNotice(noticeRequest);
-            }
-        } catch (Exception e) {
-            log.error("Failed to send review notification: {}", e.getMessage(), e);
-        }
+        reviewNotificationService.sendReviewNotifications(review);
     }
 
     @Override

--- a/src/test/java/net/pointofviews/member/service/MemberServiceTest.java
+++ b/src/test/java/net/pointofviews/member/service/MemberServiceTest.java
@@ -67,6 +67,9 @@ class MemberServiceTest {
     @Mock
     private SetOperations<String, Object> setOperations;
 
+    @Mock
+    private MemberRedisService memberRedisService;
+
     @BeforeEach
     void setUp() {
         given(redisTemplate.opsForSet()).willReturn(setOperations);
@@ -124,12 +127,11 @@ class MemberServiceTest {
                 given(memberRepository.existsByEmail(request.email())).willReturn(false);
                 given(memberRepository.save(any(Member.class))).willReturn(savedMember);
 
-                // Redis mocking
-                given(setOperations.add(any(), any())).willReturn(1L);
-
                 // 장르 코드 변환 mocking 추가
                 given(commonCodeService.convertNameToCommonCode(any(), any()))
                         .willReturn("14", "04", "01");
+
+                doNothing().when(memberRedisService).saveGenresToRedis(any(UUID.class), anyList());
 
                 // when
                 CreateMemberResponse response = memberService.signup(request);
@@ -358,9 +360,7 @@ class MemberServiceTest {
 
                 given(memberFavorGenreRepository.findGenreCodeByGenreName(any(), any())).willReturn("01", "04", "05");
 
-                // Redis mocking
-                given(setOperations.remove(any(), any())).willReturn(1L);
-                given(setOperations.add(any(), any())).willReturn(1L);
+                doNothing().when(memberRedisService).updateGenresInRedis(any(UUID.class), anyList(), anyList());
 
                 // when -- 테스트하고자 하는 행동
                 PutMemberGenreListResponse result = memberService.updateGenre(member, request);
@@ -392,9 +392,7 @@ class MemberServiceTest {
 
                 given(memberFavorGenreRepository.findGenreCodeByGenreName(any(), any())).willReturn("04", "05", "06");
 
-                // Redis mocking
-                given(setOperations.remove(any(), any())).willReturn(1L);
-                given(setOperations.add(any(), any())).willReturn(1L);
+                doNothing().when(memberRedisService).updateGenresInRedis(any(UUID.class), anyList(), anyList());
 
                 // when -- 테스트하고자 하는 행동
                 PutMemberGenreListResponse result = memberService.updateGenre(member, request);
@@ -427,9 +425,7 @@ class MemberServiceTest {
 
                 given(memberFavorGenreRepository.findGenreCodeByGenreName(any(), any())).willReturn("01", "02", "03");
 
-                // Redis mocking
-                given(setOperations.remove(any(), any())).willReturn(1L);
-                given(setOperations.add(any(), any())).willReturn(1L);
+                doNothing().when(memberRedisService).updateGenresInRedis(any(UUID.class), anyList(), anyList());
 
                 // when -- 테스트하고자 하는 행동
                 PutMemberGenreListResponse result = memberService.updateGenre(member, request);

--- a/src/test/java/net/pointofviews/review/service/ReviewMemberServiceTest.java
+++ b/src/test/java/net/pointofviews/review/service/ReviewMemberServiceTest.java
@@ -81,6 +81,9 @@ class ReviewMemberServiceTest {
     @Mock
     private S3Service s3Service;
 
+    @Mock
+    private ReviewNotificationService reviewNotificationService;
+
     @Nested
     class SaveReview {
         @Nested
@@ -103,6 +106,8 @@ class ReviewMemberServiceTest {
                         List.of("감동적인", "몰입감 있는"),
                         false
                 );
+
+                doNothing().when(reviewNotificationService).sendReviewNotifications(any(Review.class));
 
                 // when & then
                 assertSoftly(softly -> {
@@ -127,6 +132,8 @@ class ReviewMemberServiceTest {
                         List.of(),
                         false
                 );
+
+                doNothing().when(reviewNotificationService).sendReviewNotifications(any(Review.class));
 
                 // when & then
                 assertSoftly(softly -> {


### PR DESCRIPTION
## PR 설명
- ERR EXEC without MULTI 오류로 인해 redis에 선호장르가 저장되지 않는 오류 수정
- 알림 보낼 대상이 없는 경우를 예외에서 제외 및 로그에 장르명, 장르코드 추가

## 📸 스크린샷


## 고민과 해결과정
- serviceImpl내 redis 저장내용을 새로운 service로 따로 작성함. AOP 프록시가 정상적으로 동작하여 트랜잭션을 각각 관리하기 위함.
- @Transactional(propagation = Propagation.NOT_SUPPORTED) 를 추가해서 Spring의 DB 트랜잭션과 Redis 작업이 섞여서 발생하는 문제를 방지.
- 로컬환경에서는 기존코드로도 redis에 잘 저장이 되었고 오류도 없었기에 dev환경에서 테스트로 추가 테스트 필요.