### PR TITLE
feat: maxParticipants 읽기 시 유효성 추가

### DIFF
--- a/src/test/java/net/pointofviews/club/service/ClubServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/ClubServiceImplTest.java
@@ -769,8 +769,11 @@ class ClubServiceImplTest {
                     softly.assertThat(response.clubDescription()).isEqualTo("클럽 설명");
                     softly.assertThat(response.clubFavorGenres()).isEmpty();
                     softly.assertThat(response.members().memberList()).containsExactly(leader);
-                    softly.assertThat(response.clubReviewList()).isNull();
-                    softly.assertThat(response.clubMovieList()).isNull();
+
+                    softly.assertThat(response.clubReviewList().reviews().hasContent()).isFalse(); // Slice에 내용이 없는지 확인
+                    softly.assertThat(response.clubReviewList().reviews().getContent()).isEmpty(); // 내부 리스트가 비었는지 확인
+                    softly.assertThat(response.clubMovieList().clubMovies().hasContent()).isFalse();
+                    softly.assertThat(response.clubMovieList().clubMovies().getContent()).isEmpty();
                 });
 
                 verify(clubRepository, times(1)).findBasicClubInfoById(clubId);


### PR DESCRIPTION
## PR 설명
- maxParticipants 읽기 시 유효성 추가
- 클럽 상세 조회 응답 값을 멤버가 아닐 시에 반환 값 null -> 빈 리스트로 변경
- 클럽 상세 조회 테스트 수정

## 📸 스크린샷
![Screenshot 2024-12-13 at 10 20 25](https://github.com/user-attachments/assets/bd9db70d-8192-4c7a-9f2e-d554e7b5db14)
![Screenshot 2024-12-13 at 10 29 52](https://github.com/user-attachments/assets/7e6af566-5385-47de-813e-304a92d38436)


## 고민과 해결과정
