### PR TITLE
refactor: 같은 리뷰에 대해 여러 장르를 선호해도 1번만 알림 발송

### DIFF
--- a/src/main/java/net/pointofviews/notice/exception/NoticeException.java
+++ b/src/main/java/net/pointofviews/notice/exception/NoticeException.java
@@ -26,16 +26,14 @@ public class NoticeException extends BusinessException {
             super(HttpStatus.NOT_FOUND, "알림 템플릿을 찾을 수 없습니다.");
         }
     }
-
+    public static class ReviewNotFoundException extends NoticeException {
+        public ReviewNotFoundException() {
+            super(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않아 알림 전송이 불가능합니다.");
+        }
+    }
     public static class InactiveNoticeTemplateException extends NoticeException {
         public InactiveNoticeTemplateException() {
             super(HttpStatus.BAD_REQUEST, "비활성화된 알림 템플릿입니다.");
-        }
-    }
-
-    public static class NoTargetMembersFoundException extends NoticeException {
-        public NoTargetMembersFoundException(String genre, String code) {
-            super(HttpStatus.NOT_FOUND, String.format("영화장르(장르명: %s, 장르코드: %s)에 대한 알림을 받을 대상자가 없습니다.", genre, code));
         }
     }
 

--- a/src/main/java/net/pointofviews/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/net/pointofviews/notice/service/NoticeServiceImpl.java
@@ -73,14 +73,9 @@ public class NoticeServiceImpl implements NoticeService {
         // 리뷰 작성자 ID 가져오기
         Long reviewId = parseIdOrNull(request.templateVariables().get("review_id"));
 
-        if(reviewId == null){
-            log.error("리뷰가 존재하지 않아 알림 전송이 불가능합니다.");
-            return;
-        }
-
         // 리뷰의 영화에 있는 모든 장르의 선호 사용자 조회
-        Optional<Review> reviewOptional = reviewRepository.findById(reviewId);
-        Review review = reviewOptional.get();
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(NoticeException.ReviewNotFoundException::new);
         Set<UUID> targetMembers = new HashSet<>();
 
         // 각 장르별 선호 사용자 조회 및 통합 (중복 제거)

--- a/src/main/java/net/pointofviews/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/net/pointofviews/notice/service/NoticeServiceImpl.java
@@ -74,7 +74,7 @@ public class NoticeServiceImpl implements NoticeService {
         Long reviewId = parseIdOrNull(request.templateVariables().get("review_id"));
 
         if(reviewId == null){
-            log.error("리뷰({})가 존재하지 않아 알림 전송이 불가능합니다.", reviewId);
+            log.error("리뷰가 존재하지 않아 알림 전송이 불가능합니다.");
             return;
         }
 

--- a/src/main/java/net/pointofviews/review/service/ReviewNotificationService.java
+++ b/src/main/java/net/pointofviews/review/service/ReviewNotificationService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.pointofviews.common.domain.CodeGroupEnum;
 import net.pointofviews.common.service.CommonCodeService;
 import net.pointofviews.movie.domain.Movie;
-import net.pointofviews.movie.domain.MovieGenre;
 import net.pointofviews.notice.dto.request.SendNoticeRequest;
 import net.pointofviews.notice.service.NoticeService;
 import net.pointofviews.review.domain.Review;
@@ -14,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -27,27 +27,31 @@ public class ReviewNotificationService {
     @Transactional
     public void sendReviewNotifications(Review review) {
         Movie movie = review.getMovie();
-        for (MovieGenre movieGenre : movie.getGenres()) {
-            String genreName = commonCodeService.convertCommonCodeToName(
-                    movieGenre.getGenreCode(),
-                    CodeGroupEnum.MOVIE_GENRE
-            );
 
-            String noticeContent = String.format("%s 장르의 '%s'에 새로운 리뷰가 작성되었습니다.",
-                    genreName, movie.getTitle());
+        // 모든 장르 이름을 하나의 문자열로 결합
+        String allGenres = movie.getGenres().stream()
+                .map(movieGenre -> commonCodeService.convertCommonCodeToName(
+                        movieGenre.getGenreCode(),
+                        CodeGroupEnum.MOVIE_GENRE
+                ))
+                .collect(Collectors.joining(", "));
 
-            Map<String, String> templateVariables = new HashMap<>();
-            templateVariables.put("genre", genreName);
-            templateVariables.put("movieTitle", movie.getTitle());
-            templateVariables.put("review_id", String.valueOf(review.getId()));
-            templateVariables.put("notice_content", noticeContent);
+        log.info(allGenres);
 
-            SendNoticeRequest noticeRequest = new SendNoticeRequest(
-                    REVIEW_NOTICE_TEMPLATE_ID,
-                    templateVariables
-            );
+        String noticeContent = String.format("%s 장르의 '%s'에 새로운 리뷰가 작성되었습니다.",
+                allGenres, movie.getTitle());
 
-            noticeService.sendNotice(noticeRequest);
-        }
+        Map<String, String> templateVariables = new HashMap<>();
+        templateVariables.put("genre", allGenres);
+        templateVariables.put("movieTitle", movie.getTitle());
+        templateVariables.put("review_id", String.valueOf(review.getId()));
+        templateVariables.put("notice_content", noticeContent);
+
+        SendNoticeRequest noticeRequest = new SendNoticeRequest(
+                REVIEW_NOTICE_TEMPLATE_ID,
+                templateVariables
+        );
+
+        noticeService.sendNotice(noticeRequest);
     }
 }

--- a/src/main/java/net/pointofviews/review/service/ReviewNotificationService.java
+++ b/src/main/java/net/pointofviews/review/service/ReviewNotificationService.java
@@ -36,8 +36,6 @@ public class ReviewNotificationService {
                 ))
                 .collect(Collectors.joining(", "));
 
-        log.info(allGenres);
-
         String noticeContent = String.format("%s 장르의 '%s'에 새로운 리뷰가 작성되었습니다.",
                 allGenres, movie.getTitle());
 


### PR DESCRIPTION
## PR 설명
- 영화 장르가 여러개인 경우, 여러 장르를 선호해도 1번만 알림이 발송되도록 수정
- 알림내용에 모든 장르 명을 포함하도록 수정
## 📸 스크린샷


## 고민과 해결과정
