### PR TITLE
fix: 결제 승인 후 반환된 응답값 중 필요한 응답값만 받도록 수정

### DIFF
--- a/src/main/java/net/pointofviews/payment/dto/response/ConfirmPaymentResponse.java
+++ b/src/main/java/net/pointofviews/payment/dto/response/ConfirmPaymentResponse.java
@@ -1,7 +1,10 @@
 package net.pointofviews.payment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.time.LocalDateTime;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ConfirmPaymentResponse(
         String paymentKey,
         String orderId,


### PR DESCRIPTION
## PR 설명
- 결제 승인 후 반환된 응답값 중 필요한 응답값만 받도록 수정

## 📸 스크린샷


## 고민과 해결과정
