### PR TITLE
feat: 리뷰 좋아요, 좋아요 취소 구현

### DIFF
--- a/src/main/java/net/pointofviews/batch/config/ReviewLikeBatchConfig.java
+++ b/src/main/java/net/pointofviews/batch/config/ReviewLikeBatchConfig.java
@@ -1,0 +1,168 @@
+package net.pointofviews.batch.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.pointofviews.common.service.RedisService;
+import net.pointofviews.member.domain.Member;
+import net.pointofviews.member.exception.MemberException;
+import net.pointofviews.member.repository.MemberRepository;
+import net.pointofviews.review.domain.Review;
+import net.pointofviews.review.domain.ReviewLike;
+import net.pointofviews.review.domain.ReviewLikeCount;
+import net.pointofviews.review.exception.ReviewException;
+import net.pointofviews.review.repository.ReviewLikeCountRepository;
+import net.pointofviews.review.repository.ReviewLikeRepository;
+import net.pointofviews.review.repository.ReviewRepository;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class ReviewLikeBatchConfig {
+
+    private final DataSource dataSource;
+    private final PlatformTransactionManager transactionManager;
+    private final ReviewRepository reviewRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+    private final MemberRepository memberRepository;
+    private final ReviewLikeCountRepository reviewLikeCountRepository;
+    private final RedisService redisService;
+
+    private static final int CHUNK_SIZE = 100;
+
+    @Bean
+    public Job reviewLikeJob(JobRepository jobRepository) {
+        log.info("ReviewLikeJob 초기화 중");
+
+        return new JobBuilder("reviewLikeJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(reviewLikeStep(jobRepository))
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step reviewLikeStep(JobRepository jobRepository) {
+        log.info("ReviewLikeStep 초기화 중");
+
+        return new StepBuilder("reviewLikeStep", jobRepository)
+                .<String, ReviewLike>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reviewLikeRedisReader())
+                .processor(reviewLikeProcessor())
+                .writer(reviewLikeWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<String> reviewLikeRedisReader() {
+        return new ItemReader<String>() {
+            private final Set<String> keys = redisService.getKeys("ReviewLiked:*");
+            private final Iterator<String> keysIterator = keys.iterator();
+
+            @Override
+            public String read() {
+                if (keysIterator.hasNext()) {
+                    return keysIterator.next();
+                }
+                return null;
+            }
+        };
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<String, ReviewLike> reviewLikeProcessor() {
+        return key -> {
+            try {
+                // ReviewLiked:reviewId:memberId 형식에서 데이터 추출
+                String[] parts = key.split(":");
+                Long reviewId = Long.parseLong(parts[1]);
+                UUID memberId = UUID.fromString(parts[2]);
+
+                String likeStatus = redisService.getValue(key);
+                boolean isLiked = "true".equals(likeStatus);
+
+                // review와 member 조회
+                Review review = reviewRepository.findById(reviewId)
+                        .orElseThrow(() -> ReviewException.reviewNotFound(reviewId));
+
+                Member member = memberRepository.findById(memberId)
+                        .orElseThrow(() -> MemberException.memberNotFound(memberId));
+
+                // 리뷰의 총 좋아요 수 처리
+                String countKey = "ReviewLikedCount:" + reviewId;
+                String countValue = redisService.getValue(countKey);
+                if (countValue != null) {
+                    // 기존 DB의 카운트 값을 가져와서 Redis 값을 더함
+                    Long currentCount = reviewLikeCountRepository
+                            .findById(reviewId)
+                            .map(ReviewLikeCount::getReviewLikeCount)
+                            .orElse(0L);
+
+                    Long newCount = currentCount + Long.parseLong(countValue);
+
+                    ReviewLikeCount likeCount = ReviewLikeCount.builder()
+                            .review(review)
+                            .reviewLikeCount(newCount)  // 누적된 값 저장
+                            .build();
+                    reviewLikeCountRepository.save(likeCount);
+
+                    // Redis 카운트 초기화
+                    redisService.setValue(countKey, "0", Duration.ofDays(7));
+                }
+
+                // 기존 좋아요 기록이 있는지 확인
+                ReviewLike existingLike = reviewLikeRepository
+                        .findByReviewAndMember(review, member)
+                        .orElse(null);
+
+                if (existingLike != null) {
+                    // 기존 기록이 있으면 상태 업데이트
+                    existingLike.updateLikeStatus(isLiked);
+                    return existingLike;
+                } else {
+                    // 새로운 기록 생성
+                    return ReviewLike.builder()
+                            .review(review)
+                            .member(member)
+                            .isLiked(isLiked)
+                            .build();
+                }
+            } catch (Exception e) {
+                log.error("리뷰 좋아요 처리 중 오류: {} - {}", key, e.getMessage());
+                return null;  // 오류 발생 시 해당 항목 스킵
+            }
+        };
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<ReviewLike> reviewLikeWriter() {
+        return items -> {
+            reviewLikeRepository.saveAll(items);
+            log.info("{} 개의 리뷰 좋아요 데이터 저장 완료", items.size());
+        };
+    }
+}

--- a/src/main/java/net/pointofviews/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/net/pointofviews/batch/scheduler/BatchScheduler.java
@@ -43,7 +43,7 @@ public class BatchScheduler {
         }
     }
 
-    @Scheduled(cron = "0 */15 * * * *") // 15분마다 실행
+    @Scheduled(cron = "*/1 * * * * *")
     public void reviewLikeSync() {
         LocalDateTime start = LocalDateTime.now();
         log.info("리뷰 좋아요 동기화 배치 시작: {}", start);

--- a/src/main/java/net/pointofviews/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/net/pointofviews/batch/scheduler/BatchScheduler.java
@@ -42,4 +42,27 @@ public class BatchScheduler {
             log.info("관리자 좋아요 관리 배치 스케쥴링 종료: {}", end.toString());
         }
     }
+
+    @Scheduled(cron = "0 */15 * * * *") // 15분마다 실행
+    public void reviewLikeSync() {
+        LocalDateTime start = LocalDateTime.now();
+        log.info("리뷰 좋아요 동기화 배치 시작: {}", start);
+
+        try {
+            Job job = jobRegistry.getJob("reviewLikeJob");
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("runDateTime", start.toString())
+                    .toJobParameters();
+
+            jobLauncher.run(job, jobParameters);
+
+            log.info("리뷰 좋아요 동기화 배치 성공");
+        } catch (Exception ex) {
+            log.error("리뷰 좋아요 동기화 배치 실패: {}", ex.getMessage());
+        } finally {
+            LocalDateTime end = LocalDateTime.now();
+            log.info("리뷰 좋아요 동기화 배치 종료: {}", end);
+        }
+    }
 }

--- a/src/main/java/net/pointofviews/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/net/pointofviews/batch/scheduler/BatchScheduler.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Slf4j
 @Configuration
@@ -43,7 +44,7 @@ public class BatchScheduler {
         }
     }
 
-    @Scheduled(cron = "*/1 * * * * *")
+    @Scheduled(cron = "0 */1 * * * *")
     public void reviewLikeSync() {
         LocalDateTime start = LocalDateTime.now();
         log.info("리뷰 좋아요 동기화 배치 시작: {}", start);

--- a/src/main/java/net/pointofviews/common/repository/RedisRepository.java
+++ b/src/main/java/net/pointofviews/common/repository/RedisRepository.java
@@ -1,6 +1,7 @@
 package net.pointofviews.common.repository;
 
 import java.time.Duration;
+import java.util.Set;
 
 public interface RedisRepository {
     String getValue(String key);
@@ -10,4 +11,6 @@ public interface RedisRepository {
     Long addToSet(String key, String value);
 
     Boolean setIfAbsent(String key, String value, Duration ttl);
+
+    Set<String> getKeysByPattern(String pattern);
 }

--- a/src/main/java/net/pointofviews/common/repository/impl/StringRedisRepositoryImpl.java
+++ b/src/main/java/net/pointofviews/common/repository/impl/StringRedisRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.Set;
 
 @Repository
 public class StringRedisRepositoryImpl implements RedisRepository {
@@ -33,5 +34,10 @@ public class StringRedisRepositoryImpl implements RedisRepository {
     @Override
     public Boolean setIfAbsent(String key, String value, Duration ttl) {
         return redisTemplate.opsForValue().setIfAbsent(key, value, ttl);
+    }
+
+    @Override
+    public Set<String> getKeysByPattern(String pattern) {
+        return redisTemplate.keys(pattern);
     }
 }

--- a/src/main/java/net/pointofviews/common/service/RedisService.java
+++ b/src/main/java/net/pointofviews/common/service/RedisService.java
@@ -1,10 +1,12 @@
 package net.pointofviews.common.service;
 
 import java.time.Duration;
+import java.util.Set;
 
 public interface RedisService {
     String getValue(String key);
     void setValue(String key, String value, Duration ttl);
     Long addToSet(String key, String value);
     Boolean setIfAbsent(String key, String value, Duration ttl);
+    Set<String> getKeys(String pattern);
 }

--- a/src/main/java/net/pointofviews/common/service/impl/StringRedisServiceImpl.java
+++ b/src/main/java/net/pointofviews/common/service/impl/StringRedisServiceImpl.java
@@ -7,6 +7,8 @@ import net.pointofviews.common.service.RedisService;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -60,5 +62,19 @@ public class StringRedisServiceImpl implements RedisService {
             throw RedisException.redisServerError(key);
         }
         return result;
+    }
+
+    @Override
+    public Set<String> getKeys(String pattern) {
+        try {
+            Set<String> keys = redisRepository.getKeysByPattern(pattern);
+            if (keys == null) {
+                return Collections.emptySet();
+            }
+            return keys;
+        } catch (Exception e) {
+            log.error("패턴으로 키를 조회하는데 실패했습니다.: {}", pattern, e);
+            throw RedisException.redisServerError(pattern);
+        }
     }
 }

--- a/src/main/java/net/pointofviews/review/controller/ReviewMemberController.java
+++ b/src/main/java/net/pointofviews/review/controller/ReviewMemberController.java
@@ -105,10 +105,17 @@ public class ReviewMemberController implements ReviewMemberSpecification {
     }
 
     @Override
-    @PutMapping("/{movieId}/reviews/{reviewId}/likes")
+    @PutMapping("/{movieId}/reviews/{reviewId}/like")
     public ResponseEntity<BaseResponse<Void>> putReviewLike(@PathVariable Long movieId, @PathVariable Long reviewId, @AuthenticationPrincipal MemberDetailsDto memberDetailsDto) {
         reviewMemberService.updateReviewLike(movieId, reviewId, memberDetailsDto.member());
         return BaseResponse.ok("리뷰 좋아요가 성공적으로 완료되었습니다.");
+    }
+
+    @Override
+    @PutMapping("/{movieId}/reviews/{reviewId}/dislike")
+    public ResponseEntity<BaseResponse<Void>> putReviewDisLike(@PathVariable Long movieId, @PathVariable Long reviewId, @AuthenticationPrincipal MemberDetailsDto memberDetailsDto) {
+        reviewMemberService.updateReviewDisLike(movieId, reviewId, memberDetailsDto.member());
+        return BaseResponse.ok("리뷰 좋아요 취소가 성공적으로 완료되었습니다.");
     }
 
     @Override

--- a/src/main/java/net/pointofviews/review/controller/specification/ReviewMemberSpecification.java
+++ b/src/main/java/net/pointofviews/review/controller/specification/ReviewMemberSpecification.java
@@ -339,6 +339,40 @@ public interface ReviewMemberSpecification {
     ResponseEntity<BaseResponse<Void>> putReviewLike(Long movieId, Long reviewId, MemberDetailsDto memberDetailsDto);
 
     @Operation(
+            summary = "리뷰 좋아요 취소",
+            description = "특정 영화의 리뷰의 `좋아요`를 취소 하는 API."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리뷰 좋아요 취소 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "message": "리뷰 좋아요 취소가 성공적으로 완료되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "리뷰 좋아요취소 실패",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                    	"message": "리뷰(Id: 1)는 존재하지 않습니다."
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<BaseResponse<Void>> putReviewDisLike(Long movieId, Long reviewId, MemberDetailsDto memberDetailsDto);
+
+
+    @Operation(
             summary = "리뷰 이미지 업로드",
             description = "리뷰 작성 시 이미지를 업로드하는 API."
     )

--- a/src/main/java/net/pointofviews/review/domain/ReviewLike.java
+++ b/src/main/java/net/pointofviews/review/domain/ReviewLike.java
@@ -36,4 +36,8 @@ public class ReviewLike extends BaseEntity {
         this.review = review;
         this.isLiked = isLiked;
     }
+
+    public void updateLikeStatus(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
 }

--- a/src/main/java/net/pointofviews/review/domain/ReviewLikeCount.java
+++ b/src/main/java/net/pointofviews/review/domain/ReviewLikeCount.java
@@ -21,8 +21,8 @@ public class ReviewLikeCount {
     private Long reviewLikeCount;
 
     @Builder
-    private ReviewLikeCount(Review review) {
+    private ReviewLikeCount(Review review, Long reviewLikeCount) {
         this.review = review;
-        this.reviewLikeCount = 0L; // 초기값 = 0
+        this.reviewLikeCount = (reviewLikeCount != null) ? reviewLikeCount : 0L;
     }
 }

--- a/src/main/java/net/pointofviews/review/domain/ReviewLikeCount.java
+++ b/src/main/java/net/pointofviews/review/domain/ReviewLikeCount.java
@@ -25,4 +25,8 @@ public class ReviewLikeCount {
         this.review = review;
         this.reviewLikeCount = (reviewLikeCount != null) ? reviewLikeCount : 0L;
     }
+
+    public void updateCount(Long count) {
+        this.reviewLikeCount = count;
+    }
 }

--- a/src/main/java/net/pointofviews/review/exception/ReviewException.java
+++ b/src/main/java/net/pointofviews/review/exception/ReviewException.java
@@ -20,4 +20,12 @@ public class ReviewException extends BusinessException {
     public static ReviewException undefinedPreference(String preference) {
         return new ReviewException(HttpStatus.NOT_FOUND, String.format("존재하지 않는 선호 표기입니다. value: {%s}", preference));
     }
+
+    public static ReviewException alreadyLikedReview(Long reviewId) {
+        return new ReviewException(HttpStatus.BAD_REQUEST, String.format("이미 좋아요를 누른 리뷰(Id: %d)입니다.", reviewId));
+    }
+
+    public static ReviewException alreadyDislikedReview(Long reviewId) {
+        return new ReviewException(HttpStatus.BAD_REQUEST, String.format("이미 좋아요를 취소한 리뷰(Id: %d)입니다.", reviewId));
+    }
 }

--- a/src/main/java/net/pointofviews/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/net/pointofviews/review/repository/ReviewLikeRepository.java
@@ -1,5 +1,7 @@
 package net.pointofviews.review.repository;
 
+import net.pointofviews.member.domain.Member;
+import net.pointofviews.review.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +18,12 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 		 WHERE rl.review.id = :reviewId
 	""")
 	Optional<Boolean> getIsLikedByReviewId(@Param("reviewId") Long reviewId);
+
+	@Query(value = """
+        SELECT rl
+          FROM ReviewLike rl
+         WHERE rl.review = :review
+           AND rl.member = :member
+    """)
+	Optional<ReviewLike> findByReviewAndMember(@Param("review") Review review, @Param("member") Member member);
 }

--- a/src/main/java/net/pointofviews/review/service/ReviewMemberService.java
+++ b/src/main/java/net/pointofviews/review/service/ReviewMemberService.java
@@ -33,6 +33,8 @@ public interface ReviewMemberService {
 
 	void updateReviewLike(Long movieId, Long reviewId, Member loginMember);
 
+	void updateReviewDisLike(Long movieId, Long reviewId, Member loginMember);
+
 	CreateReviewImageListResponse saveReviewImages(List<MultipartFile> files, Long movieId, Member loginMember);
 
 	void deleteReviewImagesFolder(Long movieId, Member loginMember);

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.pointofviews.common.domain.CodeGroupEnum;
 import net.pointofviews.common.service.CommonCodeService;
+import net.pointofviews.common.service.RedisService;
 import net.pointofviews.common.service.S3Service;
 import net.pointofviews.member.domain.Member;
 import net.pointofviews.member.repository.MemberRepository;
@@ -15,6 +16,7 @@ import net.pointofviews.review.dto.request.CreateReviewRequest;
 import net.pointofviews.review.dto.request.ProofreadReviewRequest;
 import net.pointofviews.review.dto.request.PutReviewRequest;
 import net.pointofviews.review.dto.response.*;
+import net.pointofviews.review.exception.ReviewException;
 import net.pointofviews.review.repository.ReviewKeywordLinkRepository;
 import net.pointofviews.review.repository.ReviewLikeCountRepository;
 import net.pointofviews.review.repository.ReviewLikeRepository;
@@ -27,14 +29,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static net.pointofviews.common.exception.S3Exception.invalidTotalImageSize;
 import static net.pointofviews.member.exception.MemberException.memberNotFound;
 import static net.pointofviews.movie.exception.MovieException.movieNotFound;
-import static net.pointofviews.review.exception.ReviewException.reviewNotFound;
-import static net.pointofviews.review.exception.ReviewException.unauthorizedReview;
+import static net.pointofviews.review.exception.ReviewException.*;
 
 @Service
 @Slf4j
@@ -50,6 +52,7 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
     private final ReviewKeywordLinkRepository reviewKeywordLinkRepository;
     private final CommonCodeService commonCodeService;
     private final ReviewNotificationService reviewNotificationService;
+    private final RedisService redisService;
     private final S3Service s3Service;
 
     @Override
@@ -232,21 +235,6 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
     }
 
     @Override
-    @Transactional
-    public void updateReviewLike(Long movieId, Long reviewId, Member loginMember) {
-        // 영화, 리뷰 존재 확인
-        if (!movieRepository.existsById(movieId)) {
-            throw movieNotFound(movieId);
-        }
-
-        if (!reviewRepository.existsById(reviewId)) {
-            throw reviewNotFound(reviewId);
-        }
-
-        // redis에 좋아요 저장
-    }
-
-    @Override
     public CreateReviewImageListResponse saveReviewImages(List<MultipartFile> files, Long movieId, Member loginMember) {
         Member member = memberRepository.findById(loginMember.getId())
                 .orElseThrow(() -> memberNotFound(loginMember.getId()));
@@ -294,5 +282,70 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
                 movieId);
 
         s3Service.deleteFolder(folderPath);
+    }
+
+    @Override
+    @Transactional
+    public void updateReviewLike(Long movieId, Long reviewId, Member loginMember) {
+        validateMovieAndReview(movieId, reviewId);
+
+        String likeKey = generateLikeKey(reviewId, loginMember.getId());
+        String countKey = generateCountKey(reviewId);
+
+        if (isLiked(likeKey)) {
+            throw ReviewException.alreadyLikedReview(reviewId);
+        }
+
+        redisService.setValue(likeKey, "true", Duration.ofDays(7));
+        updateLikeCount(countKey, true);
+    }
+
+    @Override
+    @Transactional
+    public void updateReviewDisLike(Long movieId, Long reviewId, Member loginMember) {
+        validateMovieAndReview(movieId, reviewId);
+
+        String likeKey = generateLikeKey(reviewId, loginMember.getId());
+        String countKey = generateCountKey(reviewId);
+
+        if (!isLiked(likeKey)) {
+            throw ReviewException.alreadyDislikedReview(reviewId);
+        }
+
+        redisService.setValue(likeKey, "false", Duration.ofDays(7));
+        updateLikeCount(countKey, false);
+    }
+
+    // 공통 검증 메서드
+    private void validateMovieAndReview(Long movieId, Long reviewId) {
+        if (!movieRepository.existsById(movieId)) {
+            throw movieNotFound(movieId);
+        }
+        if (!reviewRepository.existsById(reviewId)) {
+            throw reviewNotFound(reviewId);
+        }
+    }
+
+    // 키 생성 메서드
+    private String generateLikeKey(Long reviewId, UUID memberId) {
+        return "ReviewLiked:" + reviewId + ":" + memberId;
+    }
+
+    private String generateCountKey(Long reviewId) {
+        return "ReviewLikedCount:" + reviewId;
+    }
+
+    // 좋아요 상태 조회
+    private boolean isLiked(String likeKey) {
+        String currentLikeStatus = redisService.getValue(likeKey);
+        return "true".equals(currentLikeStatus);
+    }
+
+    // 좋아요 수 업데이트
+    private void updateLikeCount(String countKey, boolean increment) {
+        String currentCount = redisService.getValue(countKey);
+        long count = currentCount == null ? 0L : Long.parseLong(currentCount);
+        long newCount = increment ? count + 1L : count - 1L;
+        redisService.setValue(countKey, String.valueOf(newCount), Duration.ofDays(7));
     }
 }

--- a/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/review/service/impl/ReviewMemberServiceImpl.java
@@ -3,6 +3,7 @@ package net.pointofviews.review.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.pointofviews.common.domain.CodeGroupEnum;
+import net.pointofviews.common.lock.DistributeLock;
 import net.pointofviews.common.service.CommonCodeService;
 import net.pointofviews.common.service.RedisService;
 import net.pointofviews.common.service.S3Service;
@@ -284,6 +285,7 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
         s3Service.deleteFolder(folderPath);
     }
 
+    @DistributeLock(key = "'ReviewLike:' + #reviewId + ':' + #loginMember.id")
     @Override
     @Transactional
     public void updateReviewLike(Long movieId, Long reviewId, Member loginMember) {
@@ -300,6 +302,8 @@ public class ReviewMemberServiceImpl implements ReviewMemberService {
         updateLikeCount(countKey, true);
     }
 
+
+    @DistributeLock(key = "'ReviewLike:' + #reviewId + ':' + #loginMember.id")
     @Override
     @Transactional
     public void updateReviewDisLike(Long movieId, Long reviewId, Member loginMember) {


### PR DESCRIPTION
## PR 설명
- 리뷰 좋아요, 좋아요 취소시 redis에 좋아요 내역, 리뷰당 총 좋아요 개수 저장
- 1분마다 배치처리로 db 테이블에 저장

## 📸 스크린샷
<img width="572" alt="스크린샷 2024-12-16 오후 8 43 07" src="https://github.com/user-attachments/assets/6a7454db-bc9a-4e1d-8cb8-c2823e8cdfc1" />
<img width="1611" alt="스크린샷 2024-12-16 오후 8 50 38" src="https://github.com/user-attachments/assets/0e67fdc1-cfb3-4997-a130-642ee8169a56" />


## 고민과 해결과정
