### PR TITLE
feat: 회원/비회원 구분한 isLiked 응답값 수정

### DIFF
--- a/src/main/java/net/pointofviews/club/controller/ClubController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubController.java
@@ -53,8 +53,11 @@ public class ClubController implements ClubSpecification {
     @PreAuthorize("permitAll()")
     @GetMapping("/{clubId}")
     @Override
-    public ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(@PathVariable UUID clubId, @AuthenticationPrincipal(expression = "member") Member loginMember, Pageable pageable) {
-        ReadClubDetailsResponse response = clubService.readClubDetails(clubId, loginMember, pageable);
+    public ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(@PathVariable UUID clubId, @AuthenticationPrincipal MemberDetailsDto memberDetails, Pageable pageable) {
+
+        UUID memberId = memberDetails != null ? memberDetails.member().getId() : null;
+
+        ReadClubDetailsResponse response = clubService.readClubDetails(clubId, memberId, pageable);
         return BaseResponse.ok("클럽 상세 정보를 성공적으로 조회했습니다.", response);
     }
 

--- a/src/main/java/net/pointofviews/club/controller/ClubMovieController.java
+++ b/src/main/java/net/pointofviews/club/controller/ClubMovieController.java
@@ -1,11 +1,11 @@
 package net.pointofviews.club.controller;
 
 import lombok.RequiredArgsConstructor;
+import net.pointofviews.auth.dto.MemberDetailsDto;
 import net.pointofviews.club.controller.specification.ClubMovieSpecification;
 import net.pointofviews.club.dto.response.*;
 import net.pointofviews.club.service.ClubMovieService;
 import net.pointofviews.common.dto.BaseResponse;
-import net.pointofviews.member.domain.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -26,9 +26,11 @@ public class ClubMovieController implements ClubMovieSpecification {
     @GetMapping("/{clubId}/bookmark")
     @Override
     public ResponseEntity<BaseResponse<ReadClubMoviesListResponse>> readMyClubMovies(@PathVariable UUID clubId,
-                                                                                     @AuthenticationPrincipal(expression = "member") Member loginMember,
+                                                                                     @AuthenticationPrincipal MemberDetailsDto memberDetails,
                                                                                      @PageableDefault Pageable pageable) {
-        ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, loginMember, pageable);
+        UUID memberId = memberDetails != null ? memberDetails.member().getId() : null;
+
+        ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, memberId, pageable);
 
         if (response.clubMovies().isEmpty()) {
             return BaseResponse.noContent();

--- a/src/main/java/net/pointofviews/club/controller/specification/ClubMovieSpecification.java
+++ b/src/main/java/net/pointofviews/club/controller/specification/ClubMovieSpecification.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import net.pointofviews.auth.dto.MemberDetailsDto;
 import net.pointofviews.club.dto.response.*;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.member.domain.Member;
@@ -27,7 +28,7 @@ public interface ClubMovieSpecification {
     })
     ResponseEntity<BaseResponse<ReadClubMoviesListResponse>> readMyClubMovies(
             @PathVariable UUID clubId,
-            @AuthenticationPrincipal(expression = "member") Member loginMember,
+            @AuthenticationPrincipal MemberDetailsDto memberDetails,
             @PageableDefault Pageable pageable);
 
 }

--- a/src/main/java/net/pointofviews/club/controller/specification/ClubSpecification.java
+++ b/src/main/java/net/pointofviews/club/controller/specification/ClubSpecification.java
@@ -72,7 +72,7 @@ public interface ClubSpecification {
     })
     ResponseEntity<BaseResponse<ReadClubDetailsResponse>> readClubDetails(
             @PathVariable UUID clubId,
-            @AuthenticationPrincipal(expression = "member") Member loginMember,
+            @AuthenticationPrincipal MemberDetailsDto memberDetails,
             Pageable pageable
     );
 

--- a/src/main/java/net/pointofviews/club/repository/ClubMoviesRepository.java
+++ b/src/main/java/net/pointofviews/club/repository/ClubMoviesRepository.java
@@ -17,7 +17,7 @@ public interface ClubMoviesRepository extends JpaRepository<ClubMovie, Long> {
                 m.title,
                 m.poster,
                 m.released,
-                CASE WHEN EXISTS (SELECT 1 FROM MovieLike ml WHERE ml.movie.id = m.id AND ml.member.id = :memberId AND  ml.isLiked = true) THEN true ELSE false END,
+                CASE WHEN :memberId IS NOT NULL AND EXISTS (SELECT 1 FROM MovieLike ml WHERE ml.movie.id = m.id AND ml.member.id = :memberId AND  ml.isLiked = true) THEN true ELSE false END,
                 COALESCE((SELECT mlc.likeCount FROM MovieLikeCount mlc WHERE mlc.movie.id = m.id), 0),
                 COUNT(r.id)
             )

--- a/src/main/java/net/pointofviews/club/service/ClubMovieService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubMovieService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 
 public interface ClubMovieService {
-    ReadClubMoviesListResponse readClubMovies(UUID clubId, Member loginMember, Pageable pageable);
+    ReadClubMoviesListResponse readClubMovies(UUID clubId, UUID memberId, Pageable pageable);
 
     void saveMovieToMyClub(Long movieId, UUID clubId);
 }

--- a/src/main/java/net/pointofviews/club/service/ClubService.java
+++ b/src/main/java/net/pointofviews/club/service/ClubService.java
@@ -30,7 +30,7 @@ public interface ClubService {
 
     ReadAllClubsListResponse readAllMyClubs(Member loginMember);
 
-    ReadClubDetailsResponse readClubDetails(UUID clubId, Member loginMember, Pageable pageable);
+    ReadClubDetailsResponse readClubDetails(UUID clubId, UUID memberId, Pageable pageable);
 
     ReadPrivateClubDetailsResponse readPrivateClubDetails(Member loginMember, String value);
 }

--- a/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubMovieServiceImpl.java
@@ -30,8 +30,8 @@ public class ClubMovieServiceImpl implements ClubMovieService {
     private final MovieRepository movieRepository;
 
     @Override
-    public ReadClubMoviesListResponse readClubMovies(UUID clubId, Member loginMember, Pageable pageable) {
-        Slice<ReadClubMovieResponse> movies = clubMoviesRepository.findMovieDetailsByClubId(clubId, loginMember.getId(), pageable);
+    public ReadClubMoviesListResponse readClubMovies(UUID clubId, UUID memberId, Pageable pageable) {
+        Slice<ReadClubMovieResponse> movies = clubMoviesRepository.findMovieDetailsByClubId(clubId, memberId, pageable);
         return new ReadClubMoviesListResponse(movies);
     }
 

--- a/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
+++ b/src/main/java/net/pointofviews/club/service/impl/ClubServiceImpl.java
@@ -365,7 +365,7 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public ReadClubDetailsResponse readClubDetails(UUID clubId, Member loginMember, Pageable pageable) {
+    public ReadClubDetailsResponse readClubDetails(UUID clubId, UUID memberId, Pageable pageable) {
         // 1. 클럽 기본 정보 조회
         FindBasicClubInfo basicInfo = clubRepository.findBasicClubInfoById(clubId)
                 .orElseThrow(() -> ClubException.clubNotFound(clubId));
@@ -373,13 +373,13 @@ public class ClubServiceImpl implements ClubService {
         List<String> genres = clubFavorGenreService.readGenreNamesByClubId(clubId);
 
         // 2. 클럽 가입 여부 확인
-        boolean isMember = memberClubService.isMemberOfClub(clubId, loginMember.getId());
+        boolean isMember = memberClubService.isMemberOfClub(clubId, memberId);
 
         int validatedMaxParticipants = validateMaxParticipants(basicInfo.maxParticipants());
 
         ReadClubMemberListResponse members = memberClubService.readMembersByClubId(clubId);
-        ReadMyClubReviewListResponse reviews = reviewClubService.findReviewByClub(clubId, loginMember.getId(), pageable);
-        ReadClubMoviesListResponse bookmarks = clubMovieService.readClubMovies(clubId, loginMember, pageable);
+        ReadMyClubReviewListResponse reviews = reviewClubService.findReviewByClub(clubId, memberId, pageable);
+        ReadClubMoviesListResponse bookmarks = clubMovieService.readClubMovies(clubId, memberId, pageable);
 
         int reviewCount = reviews != null ? reviews.reviews().getSize() : 0;
 

--- a/src/main/java/net/pointofviews/curation/controller/CurationMemberController.java
+++ b/src/main/java/net/pointofviews/curation/controller/CurationMemberController.java
@@ -1,6 +1,7 @@
 package net.pointofviews.curation.controller;
 
 import lombok.RequiredArgsConstructor;
+import net.pointofviews.auth.dto.MemberDetailsDto;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.curation.controller.specification.CurationMemberSpecification;
 import net.pointofviews.curation.dto.response.ReadUserCurationListResponse;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @PreAuthorize("permitAll()")
@@ -23,8 +26,11 @@ public class CurationMemberController implements CurationMemberSpecification {
 
     @GetMapping("/today")
     @Override
-    public ResponseEntity<BaseResponse<ReadUserCurationListResponse>> readScheduledCurations(@AuthenticationPrincipal(expression = "member") Member loginMember) {
-        ReadUserCurationListResponse response = curationMemberService.readUserCurations(loginMember);
+    public ResponseEntity<BaseResponse<ReadUserCurationListResponse>> readScheduledCurations(@AuthenticationPrincipal MemberDetailsDto memberDetails) {
+
+        UUID memberId = memberDetails != null ? memberDetails.member().getId() : null;
+
+        ReadUserCurationListResponse response = curationMemberService.readUserCurations(memberId);
         return BaseResponse.ok("사용자 스케줄링 된 큐레이션 조회에 성공하였습니다.", response);
     }
 }

--- a/src/main/java/net/pointofviews/curation/controller/specification/CurationMemberSpecification.java
+++ b/src/main/java/net/pointofviews/curation/controller/specification/CurationMemberSpecification.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import net.pointofviews.auth.dto.MemberDetailsDto;
 import net.pointofviews.common.dto.BaseResponse;
 import net.pointofviews.curation.dto.response.ReadUserCurationListResponse;
 import net.pointofviews.member.domain.Member;
@@ -22,6 +23,6 @@ public interface CurationMemberSpecification {
             )
     })
     ResponseEntity<BaseResponse<ReadUserCurationListResponse>> readScheduledCurations(
-            @AuthenticationPrincipal(expression = "member") Member loginMember
+            @AuthenticationPrincipal MemberDetailsDto memberDetails
     );
 }

--- a/src/main/java/net/pointofviews/curation/dto/response/ReadAdminCurationDetailResponse.java
+++ b/src/main/java/net/pointofviews/curation/dto/response/ReadAdminCurationDetailResponse.java
@@ -10,6 +10,6 @@ public record ReadAdminCurationDetailResponse(
         @Schema(description = "관리자 큐레이션 응답 DTO")
         ReadAdminCurationResponse readAdminCurationResponse,
 
-        @Schema(description = "큐레이션에 저장 될 영화 리스트", example = "[2, 5, 10]")
+        @Schema(description = "큐레이션에 저장 될 영화 리스트")
         List<ReadAdminCurationMovieResponse> readAdminCurationMovieResponseList
 ) {}

--- a/src/main/java/net/pointofviews/curation/dto/response/ReadAdminCurationMovieResponse.java
+++ b/src/main/java/net/pointofviews/curation/dto/response/ReadAdminCurationMovieResponse.java
@@ -6,13 +6,17 @@ import java.time.LocalDate;
 
 @Schema(description = "큐레이션 영화 정보 응답 DTO")
 public record ReadAdminCurationMovieResponse(
+        @Schema(description = "영화 식별자", example = "1")
+        Long movieId,
+
         @Schema(description = "영화 제목", example = "Inception")
         String title,
 
         @Schema(description = "출시일", example = "2010-07-16", format = "date")
         LocalDate released
 ) {
-        public ReadAdminCurationMovieResponse(String title, LocalDate released) {
+        public ReadAdminCurationMovieResponse(Long movieId, String title, LocalDate released) {
+                this.movieId = movieId;
                 this.title = title;
                 this.released = released;
         }

--- a/src/main/java/net/pointofviews/curation/repository/CurationRepository.java
+++ b/src/main/java/net/pointofviews/curation/repository/CurationRepository.java
@@ -52,6 +52,7 @@ public interface CurationRepository extends JpaRepository<Curation, Long> {
 
     @Query("""
        SELECT new net.pointofviews.curation.dto.response.ReadAdminCurationMovieResponse(
+           m.id,
            m.title,
            m.released
        )

--- a/src/main/java/net/pointofviews/curation/service/CurationMemberService.java
+++ b/src/main/java/net/pointofviews/curation/service/CurationMemberService.java
@@ -4,6 +4,8 @@ import net.pointofviews.curation.dto.response.ReadUserCurationListResponse;
 import net.pointofviews.member.domain.Member;
 import org.springframework.data.domain.Pageable;
 
+import java.util.UUID;
+
 public interface CurationMemberService {
-    ReadUserCurationListResponse readUserCurations(Member member);
+    ReadUserCurationListResponse readUserCurations(UUID memberId);
 }

--- a/src/main/java/net/pointofviews/curation/service/impl/CurationMemberServiceImpl.java
+++ b/src/main/java/net/pointofviews/curation/service/impl/CurationMemberServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,7 +27,7 @@ public class CurationMemberServiceImpl implements CurationMemberService {
     private final MovieRepository movieRepository;
 
     @Override
-    public ReadUserCurationListResponse readUserCurations(Member loginMember) {
+    public ReadUserCurationListResponse readUserCurations(UUID memberId) {
 
         // 오늘 활성화된 큐레이션 ID 조회
         Set<Long> curationIds = curationRedisService.readTodayCurationId();
@@ -42,7 +43,7 @@ public class CurationMemberServiceImpl implements CurationMemberService {
                     Set<Long> movieIds = curationRedisService.readMoviesForCuration(curationId);
 
                     // 영화 정보를 DB에서 조회
-                    List<ReadUserCurationMovieResponse> movieDetails = movieRepository.findUserCurationMoviesByIds(movieIds, loginMember.getId())
+                    List<ReadUserCurationMovieResponse> movieDetails = movieRepository.findUserCurationMoviesByIds(movieIds, memberId)
                             .stream()
                             .map(movie -> new ReadUserCurationMovieResponse(
                                     movie.title(),

--- a/src/main/java/net/pointofviews/movie/controller/MovieController.java
+++ b/src/main/java/net/pointofviews/movie/controller/MovieController.java
@@ -15,7 +15,9 @@ import net.pointofviews.movie.service.MovieService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -34,8 +36,11 @@ public class MovieController implements MovieSpecification {
     @PreAuthorize("permitAll()")
     @Override
     @GetMapping
-    public ResponseEntity<BaseResponse<MovieListResponse>> MovieList(@AuthenticationPrincipal(expression = "member") Member loginMember, Pageable pageable) {
-        MovieListResponse response = movieService.readMovies(loginMember, pageable);
+    public ResponseEntity<BaseResponse<MovieListResponse>> MovieList(@AuthenticationPrincipal MemberDetailsDto memberDetails,
+                                                                     Pageable pageable) {
+        UUID memberId = memberDetails != null ? memberDetails.member().getId() : null;
+
+        MovieListResponse response = movieService.readMovies(memberId, pageable);
         return BaseResponse.ok("영화가 성공적으로 조회되었습니다.", response);
     }
 
@@ -45,10 +50,13 @@ public class MovieController implements MovieSpecification {
     @Override
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<SearchMovieListResponse>> searchMovieList(
-            @AuthenticationPrincipal(expression = "member") Member loginMember,
+            @AuthenticationPrincipal MemberDetailsDto memberDetails,
             @RequestParam String query,
             Pageable pageable) {
-        SearchMovieListResponse response = movieSearchService.searchMovies(query, loginMember, pageable);
+
+        UUID memberId = memberDetails != null ? memberDetails.member().getId() : null;
+
+        SearchMovieListResponse response = movieSearchService.searchMovies(query, memberId, pageable);
         return BaseResponse.ok("영화가 성공적으로 검색되었습니다.", response);
     }
 
@@ -82,6 +90,5 @@ public class MovieController implements MovieSpecification {
         memberService.updateMovieDisLike(movieId, loginMember);
         return BaseResponse.ok("좋아요 취소가 완료되었습니다.");
     }
-
 
 }

--- a/src/main/java/net/pointofviews/movie/controller/specification/MovieSpecification.java
+++ b/src/main/java/net/pointofviews/movie/controller/specification/MovieSpecification.java
@@ -32,7 +32,7 @@ public interface MovieSpecification {
             )
     })
     ResponseEntity<BaseResponse<MovieListResponse>> MovieList(
-            @AuthenticationPrincipal(expression = "member") Member loginMember,
+            @AuthenticationPrincipal MemberDetailsDto memberDetails,
             Pageable pageable
     );
 
@@ -56,7 +56,7 @@ public interface MovieSpecification {
             )
     })
     ResponseEntity<BaseResponse<SearchMovieListResponse>> searchMovieList(
-            @AuthenticationPrincipal(expression = "member") Member loginMember,
+            @AuthenticationPrincipal MemberDetailsDto memberDetails,
             @RequestParam String query,
             Pageable pageable
     );

--- a/src/main/java/net/pointofviews/movie/repository/MovieRepository.java
+++ b/src/main/java/net/pointofviews/movie/repository/MovieRepository.java
@@ -20,13 +20,12 @@ import java.util.UUID;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
-
     @Query("""
             SELECT
                 m.title,
                 m.poster,
                 m.released,
-                CASE WHEN EXISTS (SELECT 1 FROM MovieLike ml WHERE ml.movie.id = m.id AND ml.member.id = :memberId AND  ml.isLiked = true) THEN true ELSE false END,
+                CASE WHEN :memberId IS NOT NULL AND EXISTS (SELECT 1 FROM MovieLike ml WHERE ml.movie.id = m.id AND ml.member.id = :memberId AND ml.isLiked = true) THEN true ELSE false END,
                 COALESCE((SELECT mlc.likeCount FROM MovieLikeCount mlc WHERE mlc.movie.id = m.id), 0),
                 COUNT(r.id)
             FROM Movie m
@@ -45,34 +44,34 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
            m.title AS title,
            m.poster AS poster,
            m.released AS released,
-           CASE WHEN EXISTS (
-               SELECT 1 FROM movie_like ml 
-               WHERE ml.movie_id = m.id 
-                 AND ml.member_id = :memberId 
+           CASE WHEN :memberId IS NOT NULL AND EXISTS (
+               SELECT 1 FROM movie_like ml
+               WHERE ml.movie_id = m.id
+                 AND ml.member_id = :memberId
                  AND ml.is_liked = true
            ) THEN true ELSE false END AS isLiked,
            COALESCE((
-               SELECT mlc.like_count 
-               FROM movie_like_count mlc 
+               SELECT mlc.like_count
+               FROM movie_like_count mlc
                WHERE mlc.movie_id = m.id
            ), 0) AS movieLikeCount,
-           (SELECT COUNT(*) 
-            FROM review r 
+           (SELECT COUNT(*)
+            FROM review r
             WHERE r.movie_id = m.id) AS movieReviewCount
     FROM movie m
-    WHERE MATCH(m.title) AGAINST(:query IN NATURAL LANGUAGE MODE)
+    WHERE MATCH(m.title) AGAINST(:query IN BOOLEAN MODE)
        OR EXISTS (
-           SELECT 1 
-           FROM people p 
-           JOIN movie_cast mc ON mc.people_id = p.id 
-           WHERE MATCH(p.name) AGAINST(:query IN NATURAL LANGUAGE MODE)
+           SELECT 1
+           FROM people p
+           JOIN movie_cast mc ON mc.people_id = p.id
+           WHERE MATCH(p.name) AGAINST(:query IN BOOLEAN MODE)
              AND mc.movie_id = m.id
        )
        OR EXISTS (
-           SELECT 1 
-           FROM people p 
-           JOIN movie_crew mcr ON mcr.people_id = p.id 
-           WHERE MATCH(p.name) AGAINST(:query IN NATURAL LANGUAGE MODE)
+           SELECT 1
+           FROM people p
+           JOIN movie_crew mcr ON mcr.people_id = p.id
+           WHERE MATCH(p.name) AGAINST(:query IN BOOLEAN MODE)
              AND mcr.movie_id = m.id
        )
     """,
@@ -106,7 +105,7 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
                 m.title,
                 m.poster,
                 m.released,
-                CASE WHEN EXISTS (SELECT 1 FROM MovieLike ml WHERE ml.movie.id = m.id AND ml.member.id = :memberId AND  ml.isLiked = true) THEN true ELSE false END,
+                CASE WHEN :memberId IS NOT NULL AND EXISTS (SELECT 1 FROM MovieLike ml WHERE ml.movie.id = m.id AND ml.member.id = :memberId AND  ml.isLiked = true) THEN true ELSE false END,
                 COALESCE((SELECT mlc.likeCount FROM MovieLikeCount mlc WHERE mlc.movie.id = m.id), 0),
                 COUNT(r.id)
             )

--- a/src/main/java/net/pointofviews/movie/service/MovieSearchService.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieSearchService.java
@@ -7,8 +7,10 @@ import net.pointofviews.movie.dto.response.ReadDetailMovieResponse;
 import net.pointofviews.movie.dto.response.SearchMovieListResponse;
 import org.springframework.data.domain.Pageable;
 
+import java.util.UUID;
+
 public interface MovieSearchService {
-    SearchMovieListResponse searchMovies(String query, Member loginMember, Pageable pageable);
+    SearchMovieListResponse searchMovies(String query, UUID memberId, Pageable pageable);
 
     AdminSearchMovieListResponse adminSearchMovies(String query, Pageable pageable);
 

--- a/src/main/java/net/pointofviews/movie/service/MovieService.java
+++ b/src/main/java/net/pointofviews/movie/service/MovieService.java
@@ -7,6 +7,8 @@ import net.pointofviews.movie.dto.response.MovieListResponse;
 import net.pointofviews.movie.dto.response.SearchMovieListResponse;
 import org.springframework.data.domain.Pageable;
 
+import java.util.UUID;
+
 public interface MovieService {
     void saveMovie(CreateMovieRequest request);
 
@@ -14,5 +16,5 @@ public interface MovieService {
 
     void updateMovie(Long movieId, PutMovieRequest request);
 
-    MovieListResponse readMovies(Member loginMember, Pageable pageable);
+    MovieListResponse readMovies(UUID memberId, Pageable pageable);
 }

--- a/src/main/java/net/pointofviews/movie/service/impl/MovieSearchServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/impl/MovieSearchServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -37,15 +38,15 @@ public class MovieSearchServiceImpl implements MovieSearchService {
     private final MovieLikeRepository movieLikeRepository;
 
     @Override
-    public SearchMovieListResponse searchMovies(String query, Member loginMember, Pageable pageable) {
+    public SearchMovieListResponse searchMovies(String query, UUID memberId, Pageable pageable) {
 
-        Slice<SearchMovieResponse> responses = movieRepository.searchMoviesByTitleOrPeople(query, loginMember.getId(), pageable)
+        Slice<SearchMovieResponse> responses = movieRepository.searchMoviesByTitleOrPeople(query, memberId, pageable)
                 .map(row -> new SearchMovieResponse(
                         ((Number) row[0]).longValue(),    // id
                         (String) row[1],                 // title
                         (String) row[2],                 // poster
                         row[3] != null ? LocalDate.parse(row[3].toString()) : null, // released
-                        row[4] instanceof Number ? ((Number) row[4]).intValue() == 1 : (Boolean) row[4], // isLiked
+                        row[4] != null ? (row[4] instanceof Number ? ((Number) row[4]).intValue() == 1 : (Boolean) row[4]) : false, // isLiked
                         row[5] != null ? ((Number) row[5]).longValue() : 0L,  // movieLikeCount
                         row[6] != null ? ((Number) row[6]).longValue() : 0L   // movieReviewCount
                 ));

--- a/src/main/java/net/pointofviews/movie/service/impl/MovieServiceImpl.java
+++ b/src/main/java/net/pointofviews/movie/service/impl/MovieServiceImpl.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -114,13 +115,13 @@ public class MovieServiceImpl implements MovieService {
     }
 
     @Override
-    public MovieListResponse readMovies(Member loginMember, Pageable pageable) {
-        Slice<MovieResponse> responses = movieRepository.findAllMovies(loginMember.getId(), pageable)
+    public MovieListResponse readMovies(UUID memberId, Pageable pageable) {
+        Slice<MovieResponse> responses = movieRepository.findAllMovies(memberId, pageable)
                 .map(row -> new MovieResponse(
                         (String) row[0],                 // title
                         (String) row[1],                 // poster
                         (LocalDate) row[2],                   // released
-                        row[3] instanceof Number ? ((Number) row[3]).intValue() == 1 : (Boolean) row[3], // isLiked
+                        row[3] != null ? (row[3] instanceof Number ? ((Number) row[3]).intValue() == 1 : (Boolean) row[3]) : false, // isLiked
                         row[4] != null ? ((Number) row[4]).longValue() : 0L,  // movieLikeCount
                         row[5] != null ? ((Number) row[5]).longValue() : 0L   // movieReviewCount
                 ));

--- a/src/test/java/net/pointofviews/club/service/ClubMovieServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/ClubMovieServiceImplTest.java
@@ -69,7 +69,7 @@ class ClubMovieServiceImplTest {
             given(clubMoviesRepository.findMovieDetailsByClubId(clubId, loginMember.getId(), pageable)).willReturn(movies);
 
             // when
-            ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, loginMember, pageable);
+            ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, loginMember.getId(), pageable);
 
             // then
             assertThat(response.clubMovies().getContent()).hasSize(2);
@@ -91,7 +91,7 @@ class ClubMovieServiceImplTest {
             given(clubMoviesRepository.findMovieDetailsByClubId(clubId, loginMember.getId(), pageable)).willReturn(emptyMovies);
 
             // when
-            ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, loginMember, pageable);
+            ReadClubMoviesListResponse response = clubMovieService.readClubMovies(clubId, loginMember.getId(), pageable);
 
             // then
             assertThat(response.clubMovies().getContent()).isEmpty();

--- a/src/test/java/net/pointofviews/club/service/ClubServiceImplTest.java
+++ b/src/test/java/net/pointofviews/club/service/ClubServiceImplTest.java
@@ -731,10 +731,10 @@ class ClubServiceImplTest {
                 given(memberClubService.isMemberOfClub(clubId, loginMember.getId())).willReturn(true);
                 given(memberClubService.readMembersByClubId(clubId)).willReturn(members);
                 given(reviewClubService.findReviewByClub(clubId, loginMember.getId(), Pageable.unpaged())).willReturn(reviews);
-                given(clubMovieService.readClubMovies(clubId, loginMember, Pageable.unpaged())).willReturn(bookmarks);
+                given(clubMovieService.readClubMovies(clubId, loginMember.getId(), Pageable.unpaged())).willReturn(bookmarks);
 
                 // when
-                ReadClubDetailsResponse response = clubService.readClubDetails(clubId, loginMember, Pageable.unpaged());
+                ReadClubDetailsResponse response = clubService.readClubDetails(clubId, loginMember.getId(), Pageable.unpaged());
 
 
                 // then
@@ -753,7 +753,7 @@ class ClubServiceImplTest {
                 verify(memberClubService).isMemberOfClub(clubId, loginMember.getId());
                 verify(memberClubService).readMembersByClubId(clubId);
                 verify(reviewClubService).findReviewByClub(clubId, loginMember.getId(), Pageable.unpaged());
-                verify(clubMovieService).readClubMovies(clubId, loginMember, Pageable.unpaged());
+                verify(clubMovieService).readClubMovies(clubId, loginMember.getId(), Pageable.unpaged());
 
             }
         }
@@ -770,7 +770,7 @@ class ClubServiceImplTest {
                 given(clubRepository.findBasicClubInfoById(clubId)).willReturn(Optional.empty());
 
                 // when & then
-                assertThatThrownBy(() -> clubService.readClubDetails(clubId, loginMember, Pageable.unpaged()))
+                assertThatThrownBy(() -> clubService.readClubDetails(clubId, loginMember.getId(), Pageable.unpaged()))
                         .isInstanceOf(ClubException.class)
                         .hasMessage(String.format("클럽(Id: %s)이 존재하지 않습니다.", clubId));
 

--- a/src/test/java/net/pointofviews/movie/service/MovieSearchServiceImplTest.java
+++ b/src/test/java/net/pointofviews/movie/service/MovieSearchServiceImplTest.java
@@ -93,7 +93,7 @@ class MovieSearchServiceImplTest {
                 given(movieRepository.searchMoviesByTitleOrPeople(query, loginMember.getId(), pageable)).willReturn(mockSlice);
 
                 // when
-                SearchMovieListResponse response = movieSearchService.searchMovies(query, loginMember, pageable);
+                SearchMovieListResponse response = movieSearchService.searchMovies(query, memberId, pageable);
 
                 // then
                 assertThat(response.movies().getContent()).hasSize(1); // 결과가 1개 있어야 함
@@ -122,7 +122,7 @@ class MovieSearchServiceImplTest {
                 given(movieRepository.searchMoviesByTitleOrPeople(query, loginMember.getId(), pageable)).willReturn(mockSlice);
 
                 // when
-                SearchMovieListResponse response = movieSearchService.searchMovies(query, loginMember, pageable);
+                SearchMovieListResponse response = movieSearchService.searchMovies(query, memberId, pageable);
 
                 // then
                 assertThat(response.movies().getContent()).isEmpty(); // 결과가 없어야 함
@@ -146,7 +146,7 @@ class MovieSearchServiceImplTest {
                 Slice<Object[]> mockSlice = new PageImpl<>(List.of(), pageable, 0);
                 given(movieRepository.searchMoviesByTitleOrPeople(query, loginMember.getId(),  pageable)).willReturn(mockSlice);
 
-                SearchMovieListResponse response = movieSearchService.searchMovies(query, loginMember, pageable);
+                SearchMovieListResponse response = movieSearchService.searchMovies(query, memberId, pageable);
 
                 // then
                 assertThat(response.movies().getContent()).isEmpty(); // 비어 있는 결과
@@ -168,7 +168,7 @@ class MovieSearchServiceImplTest {
 
                 // when & then
                 org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
-                    movieSearchService.searchMovies(query, loginMember, pageable);
+                    movieSearchService.searchMovies(query, memberId, pageable);
                 });
             }
         }

--- a/src/test/java/net/pointofviews/movie/service/MovieServiceImplTest.java
+++ b/src/test/java/net/pointofviews/movie/service/MovieServiceImplTest.java
@@ -159,7 +159,7 @@ public class MovieServiceImplTest {
 
 
             Slice<Object[]> mockSlice = new PageImpl<>(mockResults, pageable, mockResults.size());
-            given(movieRepository.findAllMovies(memberId, pageable)).willReturn(mockSlice);
+            given(movieRepository.findAllMovies(loginMember.getId(), pageable)).willReturn(mockSlice);
 
 
             // when

--- a/src/test/java/net/pointofviews/movie/service/MovieServiceImplTest.java
+++ b/src/test/java/net/pointofviews/movie/service/MovieServiceImplTest.java
@@ -163,7 +163,7 @@ public class MovieServiceImplTest {
 
 
             // when
-            MovieListResponse response = movieService.readMovies(loginMember, pageable);
+            MovieListResponse response = movieService.readMovies(memberId, pageable);
 
             // then
             Assertions.assertThat(response.movies().getContent()).hasSize(1); // 결과가 1개 있어야 함


### PR DESCRIPTION
## PR 설명
- 영화, 큐레이션, 클럽 조회 시 isLiked 응답값 수정
- 사용자 영화 검색 Boolean Mode로 변경
- 관련 테스트 수정
- 관리자 큐레이션 상세 조회 시 영화상세 반환 값에 movieId 값 추가


## 📸 스크린샷


## 고민과 해결과정
